### PR TITLE
1 first branch

### DIFF
--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -615,13 +615,13 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
     json_object * flow_src_tot_l4_payload_len_object;
     if (json_object_object_get_ex(root, "flow_src_tot_l4_payload_len", &flow_src_tot_l4_payload_len_object))
     {
-        result.xfer.flow_src_tot_l4_payload_len = json_object_get_int(flow_src_tot_l4_payload_len);
+        result.xfer.flow_src_tot_l4_payload_len = json_object_get_int(flow_src_tot_l4_payload_len_object);
     }
 
     json_object * flow_dst_tot_l4_payload_len_object;
     if (json_object_object_get_ex(root, "flow_dst_tot_l4_payload_len", &flow_dst_tot_l4_payload_len_object))
     {
-        result.xfer.flow_dst_tot_l4_payload_len = json_object_get_int(flow_dst_tot_l4_payload_len);
+        result.xfer.flow_dst_tot_l4_payload_len = json_object_get_int(flow_dst_tot_l4_payload_len_object);
     }
 
     json_object_put(root);

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -513,7 +513,7 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
 
     // dest_ip and dst_port data
     json_object* dest_ip;
-    if (json_object_object_get_ex(root, "dest_ip", &dest_ip))
+    if (json_object_object_get_ex(root, "dst_ip", &dest_ip))
     {
         result.dest_ip = strDuplicate(json_object_get_string(dest_ip));
     }

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1206,5 +1206,28 @@ void DeletenDPIRisk(char* originalJsonStr, char** converted_json_str)
 
 }
 
+int CheckSRCIPField(const char * json_str)
+{
+    // Parse the JSON string
+    json_object * parsed_json = json_tokener_parse(json_str);
+    if (parsed_json == NULL)
+    {
+        logger(1, "Error parsing JSON string\n");
+        return 0; // Parsing failed, assume src_ip is not present
+    }
+
+    // Check for the src_ip field
+    json_object * srcIpObject;
+    if (json_object_object_get_ex(parsed_json, "src_ip", &srcIpObject))
+    {
+        json_object_put(parsed_json); // Free the parsed JSON object
+        return 1;                     // src_ip field is present
+    }
+
+    json_object_put(parsed_json); // Free the parsed JSON object
+    return 0;                     // src_ip field is not present
+    
+}
+
 
 

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -9,6 +9,7 @@
 #define TRUE 1
 #define FALSE 0
 #define bool int
+#define RANDOM_UNINTIALIZED_NUMBER_VALUE -84742891
 
 // Define the structure for ndpiData
 struct NDPI_Risk
@@ -280,9 +281,9 @@ struct NDPI_Data getnDPIStructure(const char* ndpiJson)
     result.confidence_value = NULL;
     result.proto_id = NULL;
     result.proto_by_ip = NULL;
-    result.proto_by_ip_id = -84742891;
-    result.encrypted = -84742891;
-    result.category_id = 84742891;
+    result.proto_by_ip_id = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.encrypted = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.category_id = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.category = NULL;
 
     // Parse JSON string
@@ -473,14 +474,14 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
     result.l4_proto = NULL;
     result.proto = NULL;
     result.breed = NULL;
-    result.flow_id = -84742891;
+    result.flow_id = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.event_start = NULL;
     result.event_end = NULL;
     result.event_duration = NULL;
-    result.xfer.source.bytes = -84742891;
-    result.xfer.source.packets = -84742891;
-    result.xfer.destination.bytes = -84742891;
-    result.xfer.destination.packets = -84742891;
+    result.xfer.source.bytes = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.xfer.source.packets = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.xfer.destination.bytes = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.xfer.destination.packets = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.hostname = NULL;
 
     // Parse JSON string
@@ -776,17 +777,17 @@ static char* create_nDPI_Json_String(const struct NDPI_Data* ndpi)
         json_object_object_add(ndpiObj, "proto_by_ip", json_object_new_string(ndpi->proto_by_ip) );
     }
 
-    if (ndpi->proto_by_ip_id != -84742891)
+    if (ndpi->proto_by_ip_id != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object_object_add(ndpiObj, "proto_by_ip_id", json_object_new_int(ndpi->proto_by_ip_id));
     }
 
-    if (ndpi->encrypted != -84742891)
+    if (ndpi->encrypted != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object_object_add(ndpiObj, "encrypted", json_object_new_int(ndpi->encrypted));
     }
 
-    if (ndpi->category_id != -84742891)
+    if (ndpi->category_id != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object_object_add(ndpiObj, "category_id", json_object_new_int(ndpi->category_id));
     }
@@ -1110,7 +1111,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
 
     json_object* xfer_object = json_object_new_object();
     bool addXfer = FALSE;
-    if (rootDataStructure.xfer.source.packets != -84742891)
+    if (rootDataStructure.xfer.source.packets != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object* packets_object = json_object_new_object();
         json_object_object_add(packets_object, "packets", json_object_new_int(rootDataStructure.xfer.source.packets));
@@ -1119,7 +1120,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
         addXfer = TRUE;
     }
 
-    if (rootDataStructure.xfer.destination.packets != -84742891)
+    if (rootDataStructure.xfer.destination.packets != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object* packets_object = json_object_new_object();
         json_object_object_add(packets_object, "packets", json_object_new_int(rootDataStructure.xfer.destination.packets));

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -962,7 +962,7 @@ static void add_nDPI_Data(json_object** root_object, struct NDPI_Data nDPIStruct
     char* nDPIJsonString = create_nDPI_Json_String(&nDPIStructure);
     if (nDPIJsonString == NULL)
     {
-        fprintf(stderr, "Error parsing new ndpi JSON\n");
+        fprintf(stderr, "create_nDPI_Json_String routine returned empty string: Error parsing new ndpi JSON\n");
         return;
     }
 
@@ -1091,7 +1091,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
     }
 
     // Flow starts here
-    if (rootDataStructure.flow_id != NULL)
+    if (rootDataStructure.flow_id != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object* flow_id_object = json_object_new_object();
         json_object_object_add(flow_id_object, "id", json_object_new_int(rootDataStructure.flow_id));

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1179,7 +1179,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
     }
 }
 
-void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert)
+void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert, unsigned long long int* flow_id)
 {
     struct NDPI_Data ndpiData = getnDPIStructure(originalJsonStr);
     *createAlert = ndpiData.flow_risk_count;
@@ -1188,6 +1188,11 @@ void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int
     add_nDPI_Data(&root_object, ndpiData);
 
     struct Root_data rootData = getRootDataStructure(originalJsonStr);
+    if (rootData.flow_id != RANDOM_UNINTIALIZED_NUMBER_VALUE) 
+    {
+        *flow_id = rootData.flow_id
+    }
+
     add_Root_Data(&root_object, rootData, ndpiData.flow_risk_count);
 
     *converted_json_str = strDuplicate(json_object_to_json_string(root_object));

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1181,7 +1181,6 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
 
 void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert)
 {
-    logger(1, "ConvertnDPIDataFormat: %s\n", originalJsonStr);
     struct NDPI_Data ndpiData = getnDPIStructure(originalJsonStr);
     *createAlert = ndpiData.flow_risk_count;
 

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1169,6 +1169,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
 
 void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert)
 {
+    fprintf(stderr, "ConvertnDPIDataFormat: %s\n", originalJsonStr);
     struct NDPI_Data ndpiData = getnDPIStructure(originalJsonStr);
     *createAlert = ndpiData.flow_risk_count;
 

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1190,7 +1190,7 @@ void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int
     struct Root_data rootData = getRootDataStructure(originalJsonStr);
     if (rootData.flow_id != RANDOM_UNINTIALIZED_NUMBER_VALUE) 
     {
-        *flow_id = rootData.flow_id
+        *flow_id = rootData.flow_id;
     }
 
     add_Root_Data(&root_object, rootData, ndpiData.flow_risk_count);

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1078,30 +1078,32 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
     // Event starts here
 
     json_object* event_object = json_object_new_object();
-    bool addEvent = FALSE;
-
+   
     if (rootDataStructure.event_start != NULL)
     {
         json_object_object_add(event_object, "start", json_object_new_string(rootDataStructure.event_start));
-        addEvent = TRUE;
     }
     if (rootDataStructure.event_end != NULL)
     {
         json_object_object_add(event_object, "end", json_object_new_string(rootDataStructure.event_end));
-        addEvent = TRUE;
     }
 
     if (rootDataStructure.event_duration != NULL)
     {
         json_object_object_add(event_object, "duration", json_object_new_string(rootDataStructure.event_duration));
-        addEvent = TRUE;
     }
 
-    if (addEvent)
+    if (flowRiskCount > 0)
     {
-        json_object_object_add(*root_object, "event", event_object);
+        json_object_object_add(event_object, "kind", json_object_new_string("alert"));
+    }
+    else
+    {
+        json_object_object_add(event_object, "kind", json_object_new_string("event"));
     }
 
+    json_object_object_add(*root_object, "event", event_object);
+    
     // Flow starts here
     if (rootDataStructure.flow_id != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
@@ -1164,19 +1166,6 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
         json_object_object_add(full_object, "full", json_object_new_string(rootDataStructure.hostname));
         json_object_object_add(*root_object, "url", full_object);    
     }   
-
-    if (flowRiskCount > 0)
-    {
-        json_object* event_object = json_object_new_object();
-        json_object_object_add(event_object, "kind", json_object_new_string("alert"));
-        json_object_object_add(*root_object, "event", event_object);
-    }
-    else
-    {
-		json_object* event_object = json_object_new_object();
-		json_object_object_add(event_object, "kind", json_object_new_string("event"));
-		json_object_object_add(*root_object, "event", event_object);        
-    }
 }
 
 void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert, unsigned long long int* flow_id)

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -1169,7 +1169,7 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
 
 void ConvertnDPIDataFormat(char* originalJsonStr, char** converted_json_str, int* createAlert)
 {
-    fprintf(stderr, "ConvertnDPIDataFormat: %s\n", originalJsonStr);
+    logger(1, "ConvertnDPIDataFormat: %s\n", originalJsonStr);
     struct NDPI_Data ndpiData = getnDPIStructure(originalJsonStr);
     *createAlert = ndpiData.flow_risk_count;
 

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -606,10 +606,22 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
         result.xfer.source.packets = json_object_get_int(flow_src_packets_processed_object);
     }
 
+    json_object * src2dst_bytes_object;
+    if (json_object_object_get_ex(root, "src2dst_bytes", &src2dst_bytes_object))
+    {
+        result.xfer.source.bytes = json_object_get_int(src2dst_bytes_object);
+    }
+
     json_object * flow_dst_packets_processed_object;
     if (json_object_object_get_ex(root, "flow_dst_packets_processed", &flow_dst_packets_processed_object))
     {
         result.xfer.destination.packets = json_object_get_int(flow_dst_packets_processed_object);
+    }
+
+    json_object * dst2src_bytes_object;
+    if (json_object_object_get_ex(root, "dst2src_bytes", &dst2src_bytes_object))
+    {
+        result.xfer.destination.bytes = json_object_get_int(dst2src_bytes_object);
     }
 
     json_object * flow_src_tot_l4_payload_len_object;

--- a/nDPIJsonDataConverter.c
+++ b/nDPIJsonDataConverter.c
@@ -51,6 +51,8 @@ struct Root_xfer
 {
     struct Xfer_Packets source;
     struct Xfer_Packets destination;
+    int flow_src_tot_l4_payload_len;
+    int flow_dst_tot_l4_payload_len;
 };
 
 struct Root_data
@@ -482,6 +484,8 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
     result.xfer.source.packets = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.xfer.destination.bytes = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.xfer.destination.packets = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.xfer.flow_src_tot_l4_payload_len = RANDOM_UNINTIALIZED_NUMBER_VALUE;
+    result.xfer.flow_dst_tot_l4_payload_len = RANDOM_UNINTIALIZED_NUMBER_VALUE;
     result.hostname = NULL;
 
     // Parse JSON string
@@ -596,41 +600,28 @@ static struct Root_data getRootDataStructure(const char* originalJsonStr)
 
 
     // xfer
-    json_object* xfer_object;
-    if (json_object_object_get_ex(root, "xfer", &xfer_object))
+    json_object * flow_src_packets_processed_object;
+    if (json_object_object_get_ex(root, "flow_src_packets_processed", &flow_src_packets_processed_object))
     {
-        json_object* source_object;
-        if (json_object_object_get_ex(xfer_object, "source", &source_object))
-        {
-            json_object* packets_object;
-            if (json_object_object_get_ex(source_object, "packets", &packets_object))
-            {
-                result.xfer.source.packets = json_object_get_int(packets_object);
-            }
+        result.xfer.source.packets = json_object_get_int(flow_src_packets_processed_object);
+    }
 
-            json_object* bytes_object;
-            if (json_object_object_get_ex(source_object, "bytes", &bytes_object))
-            {
-                result.xfer.source.bytes = json_object_get_int(bytes_object);
-            }
+    json_object * flow_dst_packets_processed_object;
+    if (json_object_object_get_ex(root, "flow_dst_packets_processed", &flow_dst_packets_processed_object))
+    {
+        result.xfer.destination.packets = json_object_get_int(flow_dst_packets_processed_object);
+    }
 
-        }
+    json_object * flow_src_tot_l4_payload_len_object;
+    if (json_object_object_get_ex(root, "flow_src_tot_l4_payload_len", &flow_src_tot_l4_payload_len_object))
+    {
+        result.xfer.flow_src_tot_l4_payload_len = json_object_get_int(flow_src_tot_l4_payload_len);
+    }
 
-        json_object* destination_object;
-        if (json_object_object_get_ex(xfer_object, "destination", &destination_object))
-        {
-            json_object* packets_object;
-            if (json_object_object_get_ex(destination_object, "packets", &packets_object))
-            {
-                result.xfer.destination.packets = json_object_get_int(packets_object);
-            }
-
-            json_object* bytes_object;
-            if (json_object_object_get_ex(destination_object, "bytes", &bytes_object))
-            {
-                result.xfer.destination.bytes = json_object_get_int(bytes_object);
-            }
-        }
+    json_object * flow_dst_tot_l4_payload_len_object;
+    if (json_object_object_get_ex(root, "flow_dst_tot_l4_payload_len", &flow_dst_tot_l4_payload_len_object))
+    {
+        result.xfer.flow_dst_tot_l4_payload_len = json_object_get_int(flow_dst_tot_l4_payload_len);
     }
 
     json_object_put(root);
@@ -1114,8 +1105,12 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
     if (rootDataStructure.xfer.source.packets != RANDOM_UNINTIALIZED_NUMBER_VALUE)
     {
         json_object* packets_object = json_object_new_object();
+      
         json_object_object_add(packets_object, "packets", json_object_new_int(rootDataStructure.xfer.source.packets));
-        json_object_object_add(packets_object, "bytes", json_object_new_int(rootDataStructure.xfer.source.bytes));
+        if (rootDataStructure.xfer.source.bytes != RANDOM_UNINTIALIZED_NUMBER_VALUE)
+        {
+            json_object_object_add(packets_object, "bytes", json_object_new_int(rootDataStructure.xfer.source.bytes));
+        }
         json_object_object_add(xfer_object, "source", packets_object);
         addXfer = TRUE;
     }
@@ -1124,8 +1119,24 @@ static void add_Root_Data(json_object** root_object,  struct Root_data rootDataS
     {
         json_object* packets_object = json_object_new_object();
         json_object_object_add(packets_object, "packets", json_object_new_int(rootDataStructure.xfer.destination.packets));
-        json_object_object_add(packets_object, "bytes", json_object_new_int(rootDataStructure.xfer.destination.bytes));
+        if (rootDataStructure.xfer.destination.bytes != RANDOM_UNINTIALIZED_NUMBER_VALUE)
+        {
+            json_object_object_add(packets_object, "bytes", json_object_new_int(rootDataStructure.xfer.destination.bytes));
+        }
+       
         json_object_object_add(xfer_object, "destination", packets_object);
+        addXfer = TRUE;
+    }
+
+    if (rootDataStructure.xfer.flow_src_tot_l4_payload_len != RANDOM_UNINTIALIZED_NUMBER_VALUE)
+    {
+        json_object_object_add(xfer_object, "src2dst_goodput_bytes",  json_object_new_int(rootDataStructure.xfer.flow_src_tot_l4_payload_len));
+        addXfer = TRUE;
+    }
+
+    if (rootDataStructure.xfer.flow_dst_tot_l4_payload_len != RANDOM_UNINTIALIZED_NUMBER_VALUE)
+    {
+        json_object_object_add(xfer_object, "dst2src_goodput_bytes",  json_object_new_int(rootDataStructure.xfer.flow_dst_tot_l4_payload_len));
         addXfer = TRUE;
     }
 

--- a/nDPIJsonDataConverter.h
+++ b/nDPIJsonDataConverter.h
@@ -4,6 +4,7 @@ extern "C" {
 
 void ConvertnDPIDataFormat(char* jsonStr, char** converted_json_str, int* createAlert);
 void DeletenDPIRisk(char* jsonStr, char** converted_json_str);
+int CheckSRCIPField(const char * json_str);
 
 #ifdef __cplusplus
 }

--- a/nDPIJsonDataConverter.h
+++ b/nDPIJsonDataConverter.h
@@ -2,7 +2,7 @@
 extern "C" {
 #endif
 
-void ConvertnDPIDataFormat(char* jsonStr, char** converted_json_str, int* createAlert);
+void ConvertnDPIDataFormat(char* jsonStr, char** converted_json_str, int* createAlert,  unsigned long long int* flow_id);
 void DeletenDPIRisk(char* jsonStr, char** converted_json_str);
 int CheckSRCIPField(const char * json_str);
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -815,6 +815,7 @@ static enum nDPIsrvd_callback_return distributor_json_callback(struct nDPIsrvd_s
                                                                struct nDPIsrvd_thread_data * const thread_data,
                                                                struct nDPIsrvd_flow * const flow)
 {
+    logger(0, "distributor_json_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct distributor_instance_user_data * instance_stats =
@@ -1048,7 +1049,7 @@ static enum nDPIsrvd_callback_return distributor_json_callback(struct nDPIsrvd_s
             }
         }
     }
-
+    logger(0, "distributor_json_callback END");
     return CALLBACK_OK;
 callback_error:
     logger(1, "%s", "Distributor error..");
@@ -1059,6 +1060,7 @@ static void distributor_instance_cleanup_callback(struct nDPIsrvd_socket * const
                                                   struct nDPIsrvd_instance * const instance,
                                                   enum nDPIsrvd_cleanup_reason reason)
 {
+    logger(0, "distributor_instance_cleanup_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct nDPIsrvd_thread_data * current_thread_data;
@@ -1081,6 +1083,8 @@ static void distributor_instance_cleanup_callback(struct nDPIsrvd_socket * const
         global_stats->thread_user_data.flow_idle_count += tud->flow_idle_count;
     }
     global_stats->instance_user_data = *(struct distributor_instance_user_data *)instance->instance_user_data;
+
+    logger(0, "distributor_instance_cleanup_callback END");
 }
 
 static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const sock,
@@ -1089,6 +1093,7 @@ static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const soc
                                               struct nDPIsrvd_flow * const flow,
                                               enum nDPIsrvd_cleanup_reason reason)
 {
+    logger(0, "distributor_flow_cleanup_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct distributor_flow_user_data * const flow_stats = (struct distributor_flow_user_data *)flow->flow_user_data;
@@ -1148,6 +1153,8 @@ static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const soc
         global_stats->total_l4_payload_len += flow_stats->flow_total_l4_data_len;
         global_stats->cur_idle_flows--;
     }
+
+    logger(0, "distributor_flow_cleanup_callback END");
 }
 
 static enum nDPIsrvd_callback_return distributor_json_mock_buff_callback(

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -815,6 +815,7 @@ static enum nDPIsrvd_callback_return distributor_json_callback(struct nDPIsrvd_s
                                                                struct nDPIsrvd_thread_data * const thread_data,
                                                                struct nDPIsrvd_flow * const flow)
 {
+    logger(0, "Ashwani: distributor_json_callback");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct distributor_instance_user_data * instance_stats =
@@ -1594,8 +1595,9 @@ static void * nDPId_mainloop_thread(void * const arg)
         goto error;
     }
 
-   
+    logger(0, "Ashwani Kumar: before <run_pcap_loop>");
     run_pcap_loop(&reader_threads[0], generated_tmp_json_files_alerts[currentFileIndex],  generated_tmp_json_files_events[currentFileIndex]);
+    logger(0, "Ashwani Kumar: after <run_pcap_loop>");
 
     process_remaining_flows();
     for (size_t i = 0; i < nDPId_options.reader_thread_count; ++i)

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -310,47 +310,72 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
     {
         if (entry->d_type == DT_REG)
         { 
-            char * filename = entry->d_name;        
+    
+            char * filename = entry->d_name;
             if (strstr(filename, ".pcap") != NULL || strstr(filename, ".pcapng") != NULL)
-            {             
-                logger(0, "fetch_files_to_process 1 %s", filename);
+            {
+                // Allocate and construct the complete path of pcap file
                 char * complete_path_of_pcap = malloc(strlen(pcap_files_folder_path) + strlen(filename) + 2);
-                logger(0, "fetch_files_to_process 2");
-                sprintf(complete_path_of_pcap, "%s%s", pcap_files_folder_path, filename);
-                
-                pcap_files[number_of_valid_files_found] = complete_path_of_pcap;
-                logger(0, "fetch_files_to_process 3");
+                if (complete_path_of_pcap == NULL)
+                {
+                    logger(1, "Memory allocation failed");
+                    free(current_directory);
+                    closedir(dir);
+                    exit(EXIT_FAILURE);
+                }
+                snprintf(complete_path_of_pcap, strlen(pcap_files_folder_path) + strlen(filename) + 2, "%s/%s", pcap_files_folder_path, filename);
 
+                pcap_files[number_of_valid_files_found] = complete_path_of_pcap;
+
+                // Remove the file extension
                 char * dot = strrchr(filename, '.');
                 if (dot != NULL)
                 {
                     *dot = '\0'; // Replace the dot with the null terminator
                 }
 
-                logger(0, "fetch_files_to_process 4");
-                char * alert_file_path = malloc(strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6);
-                char * event_file_path = malloc(strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6);
-                sprintf(alert_file_path, "%s/%s/%s.%s", current_directory, alerts_folder_name, filename, "json");
-                sprintf(event_file_path, "%s/%s/%s.%s", current_directory, events_folder_name, filename, "json");
-                logger(0, "fetch_files_to_process 5");
+                // Allocate and construct alert and event file paths
+                char * alert_file_path =  malloc(strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6);
+                char * event_file_path =  malloc(strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6);
+                if (alert_file_path == NULL || event_file_path == NULL)
+                {
+                    logger(1, "Memory allocation failed");
+                    free(current_directory);
+                    free(complete_path_of_pcap);
+                    free(alert_file_path);
+                    free(event_file_path);
+                    closedir(dir);
+                    exit(EXIT_FAILURE);
+                }
+
+                snprintf(alert_file_path, strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6, "%s/%s/%s.json", current_directory,   alerts_folder_name,  filename);
+                snprintf(event_file_path, strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6,"%s/%s/%s.json", current_directory,events_folder_name, filename);
 
                 generated_json_files_alerts[number_of_valid_files_found] = alert_file_path;
                 generated_json_files_events[number_of_valid_files_found] = event_file_path;
-                logger(0, "fetch_files_to_process 6");
-               
-                logger(0, "fetch_files_to_process A %d", strlen(alert_file_path));
-                char * tmp_alert_file_path = malloc(strlen(alert_file_path) + 4);
-                logger(0, "fetch_files_to_process B %d", strlen(event_file_path));
-                char * tmp_event_file_path = malloc(strlen(event_file_path) + 4);
-                logger(0, "fetch_files_to_process C %d", strlen(event_file_path));
-                sprintf(tmp_alert_file_path, "%s.%s", alert_file_path, "tmp");
-                sprintf(tmp_event_file_path, "%s.%s", event_file_path, "tmp");
-                logger(0, "fetch_files_to_process 7");
-               
+
+                // Allocate and construct temporary alert and event file paths
+                char * tmp_alert_file_path = malloc(strlen(alert_file_path) + 5);
+                char * tmp_event_file_path = malloc(strlen(event_file_path) + 5);
+                if (tmp_alert_file_path == NULL || tmp_event_file_path == NULL)
+                {
+                    logger(1, "Memory allocation failed");
+                    free(current_directory);
+                    free(complete_path_of_pcap);
+                    free(alert_file_path);
+                    free(event_file_path);
+                    free(tmp_alert_file_path);
+                    free(tmp_event_file_path);
+                    closedir(dir);
+                    exit(EXIT_FAILURE);
+                }
+                snprintf(tmp_alert_file_path, strlen(alert_file_path) + 5, "%s.tmp", alert_file_path);
+                snprintf(tmp_event_file_path, strlen(event_file_path) + 5, "%s.tmp", event_file_path);
+
                 generated_tmp_json_files_alerts[number_of_valid_files_found] = tmp_alert_file_path;
                 generated_tmp_json_files_events[number_of_valid_files_found] = tmp_event_file_path;
+
                 number_of_valid_files_found++;
-                logger(0, "fetch_files_to_process 8");
             }
         }
     }

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -815,7 +815,6 @@ static enum nDPIsrvd_callback_return distributor_json_callback(struct nDPIsrvd_s
                                                                struct nDPIsrvd_thread_data * const thread_data,
                                                                struct nDPIsrvd_flow * const flow)
 {
-    logger(0, "distributor_json_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct distributor_instance_user_data * instance_stats =
@@ -1049,7 +1048,6 @@ static enum nDPIsrvd_callback_return distributor_json_callback(struct nDPIsrvd_s
             }
         }
     }
-    logger(0, "distributor_json_callback END");
     return CALLBACK_OK;
 callback_error:
     logger(1, "%s", "Distributor error..");
@@ -1060,7 +1058,6 @@ static void distributor_instance_cleanup_callback(struct nDPIsrvd_socket * const
                                                   struct nDPIsrvd_instance * const instance,
                                                   enum nDPIsrvd_cleanup_reason reason)
 {
-    logger(0, "distributor_instance_cleanup_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct nDPIsrvd_thread_data * current_thread_data;
@@ -1083,8 +1080,6 @@ static void distributor_instance_cleanup_callback(struct nDPIsrvd_socket * const
         global_stats->thread_user_data.flow_idle_count += tud->flow_idle_count;
     }
     global_stats->instance_user_data = *(struct distributor_instance_user_data *)instance->instance_user_data;
-
-    logger(0, "distributor_instance_cleanup_callback END");
 }
 
 static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const sock,
@@ -1093,7 +1088,6 @@ static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const soc
                                               struct nDPIsrvd_flow * const flow,
                                               enum nDPIsrvd_cleanup_reason reason)
 {
-    logger(0, "distributor_flow_cleanup_callback START");
     struct distributor_global_user_data * const global_stats =
         (struct distributor_global_user_data *)sock->global_user_data;
     struct distributor_flow_user_data * const flow_stats = (struct distributor_flow_user_data *)flow->flow_user_data;
@@ -1153,8 +1147,6 @@ static void distributor_flow_cleanup_callback(struct nDPIsrvd_socket * const soc
         global_stats->total_l4_payload_len += flow_stats->flow_total_l4_data_len;
         global_stats->cur_idle_flows--;
     }
-
-    logger(0, "distributor_flow_cleanup_callback END");
 }
 
 static enum nDPIsrvd_callback_return distributor_json_mock_buff_callback(
@@ -1174,7 +1166,6 @@ static enum nDPIsrvd_callback_return distributor_json_printer(struct nDPIsrvd_so
     (void)instance;
     (void)thread_data;
     (void)flow;
-    logger(0, "distributor_json_printer START");
     {
         struct nDPIsrvd_json_token const * const daemon_event_name = TOKEN_GET_SZ(sock, "daemon_event_name");
 
@@ -1195,7 +1186,6 @@ static enum nDPIsrvd_callback_return distributor_json_printer(struct nDPIsrvd_so
     //       nDPIsrvd_json_buffer_length(sock),
     //       nDPIsrvd_json_buffer_string(sock));
 
-    logger(0, "distributor_json_printer END");
     return CALLBACK_OK;
 }
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1189,10 +1189,11 @@ static enum nDPIsrvd_callback_return distributor_json_printer(struct nDPIsrvd_so
         }
     }
 
-    printf("%0" NETWORK_BUFFER_LENGTH_DIGITS_STR "llu%.*s",
-           sock->buffer.json_message_length - NETWORK_BUFFER_LENGTH_DIGITS,
-           nDPIsrvd_json_buffer_length(sock),
-           nDPIsrvd_json_buffer_string(sock));
+    // Ashwani: This prevents the output to stdout
+    //printf("%0" NETWORK_BUFFER_LENGTH_DIGITS_STR "llu%.*s",
+    //       sock->buffer.json_message_length - NETWORK_BUFFER_LENGTH_DIGITS,
+    //       nDPIsrvd_json_buffer_length(sock),
+    //       nDPIsrvd_json_buffer_string(sock));
 
     logger(0, "distributor_json_printer END");
     return CALLBACK_OK;

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1984,7 +1984,7 @@ int main(int argc, char ** argv)
     fetch_files_to_process_and_set_default_options(argv[1]);
 
     currentFileIndex = 0;
-    for (currentFileIndex = 0; currentFileIndex < 1; currentFileIndex++)
+    for (currentFileIndex = 0; currentFileIndex < number_of_valid_files_found; currentFileIndex++)
     {
         set_cmdarg(&nDPId_options.pcap_file_or_interface, pcap_files[currentFileIndex]);
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2013,26 +2013,26 @@ int main(int argc, char ** argv)
 
         pthread_t nDPIsrvd_thread;
         struct thread_return_value nDPIsrvd_return = {};
-        if (pthread_create(&nDPIsrvd_thread, NULL, nDPIsrvd_mainloop_thread, &nDPIsrvd_return) != 0)
-        {
-            continue;
-        }
+        //if (pthread_create(&nDPIsrvd_thread, NULL, nDPIsrvd_mainloop_thread, &nDPIsrvd_return) != 0)
+        //{
+        //    continue;
+        //}
 
         pthread_t distributor_thread;
         struct distributor_return_value distributor_return = {};
-        if (pthread_create(&distributor_thread, NULL, distributor_client_mainloop_thread, &distributor_return) != 0)
-        {
-            continue;
-        }
+        //if (pthread_create(&distributor_thread, NULL, distributor_client_mainloop_thread, &distributor_return) != 0)
+        //{
+        //    continue;
+        //}
 
         /* Try to gracefully shutdown all threads. */
-        while (thread_wait_for_termination(distributor_thread, 1, &distributor_return.thread_return_value) == 0)
-        {
-            if (THREADS_RETURNED_ERROR() != 0)
-            {
-                break;
-            }
-        }
+        //while (thread_wait_for_termination(distributor_thread, 1, &distributor_return.thread_return_value) == 0)
+        //{
+        //    if (THREADS_RETURNED_ERROR() != 0)
+        //    {
+        //        break;
+        //    }
+        //}
 
 
         while (thread_wait_for_termination(nDPId_thread, 1, &nDPId_return.thread_return_value) == 0)
@@ -2043,13 +2043,13 @@ int main(int argc, char ** argv)
             }
         }
 
-        while (thread_wait_for_termination(nDPIsrvd_thread, 1, &nDPIsrvd_return) == 0)
-        {
-            if (THREADS_RETURNED_ERROR() != 0)
-            {
-                break;
-            }
-        }
+        //while (thread_wait_for_termination(nDPIsrvd_thread, 1, &nDPIsrvd_return) == 0)
+        //{
+        //    if (THREADS_RETURNED_ERROR() != 0)
+        //    {
+        //        break;
+        //    }
+        //}
 
         logger(0, "%s", "All worker threads terminated..");
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2390,10 +2390,13 @@ int main(int argc, char ** argv)
             return 1;
         }
 
+        logger(0, "ASHWANI before renameCurrentTempFile");
+
         renameCurrentTempFile();
         remove(pcap_files[currentFileIndex]);
         free(pcap_files[currentFileIndex]);
         pcap_files[currentFileIndex] = NULL;
+        logger(0, "ASHWANI after renameCurrentTempFile");
 
 #ifdef ENABLE_ZLIB
         if (MT_GET_AND_ADD(zlib_compressions, 0) != MT_GET_AND_ADD(zlib_decompressions, 0))

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -338,8 +338,11 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                 generated_json_files_events[number_of_valid_files_found] = event_file_path;
                 logger(0, "fetch_files_to_process 6");
                
+                logger(0, "fetch_files_to_process A %d", strlen(alert_file_path));
                 char * tmp_alert_file_path = malloc(strlen(alert_file_path) + 4);
+                logger(0, "fetch_files_to_process B %d", strlen(event_file_path));
                 char * tmp_event_file_path = malloc(strlen(event_file_path) + 4);
+                logger(0, "fetch_files_to_process C %d", strlen(event_file_path));
                 sprintf(tmp_alert_file_path, "%s.%s", alert_file_path, "tmp");
                 sprintf(tmp_event_file_path, "%s.%s", event_file_path, "tmp");
                 logger(0, "fetch_files_to_process 7");

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -312,11 +312,14 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
         { 
             char * filename = entry->d_name;        
             if (strstr(filename, ".pcap") != NULL || strstr(filename, ".pcapng") != NULL)
-            {                
+            {             
+                logger(0, "fetch_files_to_process 1 %s", filename);
                 char * complete_path_of_pcap = malloc(strlen(pcap_files_folder_path) + strlen(filename) + 2);
+                logger(0, "fetch_files_to_process 2");
                 sprintf(complete_path_of_pcap, "%s%s", pcap_files_folder_path, filename);
                 
                 pcap_files[number_of_valid_files_found] = complete_path_of_pcap;
+                logger(0, "fetch_files_to_process 3");
 
                 char * dot = strrchr(filename, '.');
                 if (dot != NULL)
@@ -324,23 +327,27 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                     *dot = '\0'; // Replace the dot with the null terminator
                 }
 
+                logger(0, "fetch_files_to_process 4");
                 char * alert_file_path = malloc(strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6);
                 char * event_file_path = malloc(strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6);
                 sprintf(alert_file_path, "%s/%s/%s.%s", current_directory, alerts_folder_name, filename, "json");
                 sprintf(event_file_path, "%s/%s/%s.%s", current_directory, events_folder_name, filename, "json");
-
+                logger(0, "fetch_files_to_process 5");
 
                 generated_json_files_alerts[number_of_valid_files_found] = alert_file_path;
                 generated_json_files_events[number_of_valid_files_found] = event_file_path;
+                logger(0, "fetch_files_to_process 6");
                
                 char * tmp_alert_file_path = malloc(strlen(alert_file_path) + 4);
                 char * tmp_event_file_path = malloc(strlen(event_file_path) + 4);
                 sprintf(tmp_alert_file_path, "%s.%s", alert_file_path, "tmp");
                 sprintf(tmp_event_file_path, "%s.%s", event_file_path, "tmp");
+                logger(0, "fetch_files_to_process 7");
                
                 generated_tmp_json_files_alerts[number_of_valid_files_found] = tmp_alert_file_path;
                 generated_tmp_json_files_events[number_of_valid_files_found] = tmp_event_file_path;
                 number_of_valid_files_found++;
+                logger(0, "fetch_files_to_process 8");
             }
         }
     }

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1174,7 +1174,7 @@ static enum nDPIsrvd_callback_return distributor_json_printer(struct nDPIsrvd_so
     (void)instance;
     (void)thread_data;
     (void)flow;
-
+    logger(0, "distributor_json_printer START");
     {
         struct nDPIsrvd_json_token const * const daemon_event_name = TOKEN_GET_SZ(sock, "daemon_event_name");
 
@@ -1193,6 +1193,8 @@ static enum nDPIsrvd_callback_return distributor_json_printer(struct nDPIsrvd_so
            sock->buffer.json_message_length - NETWORK_BUFFER_LENGTH_DIGITS,
            nDPIsrvd_json_buffer_length(sock),
            nDPIsrvd_json_buffer_string(sock));
+
+    logger(0, "distributor_json_printer END");
     return CALLBACK_OK;
 }
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2392,6 +2392,7 @@ int main(int argc, char ** argv)
 
         logger(0, "ASHWANI before renameCurrentTempFile");
 
+        free_messages();
         renameCurrentTempFile();
         remove(pcap_files[currentFileIndex]);
         free(pcap_files[currentFileIndex]);

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1634,7 +1634,7 @@ error:
     free_reader_threads();
     close(mock_pipefds[PIPE_nDPId]);
  
-    write_flow_map_file(generated_tmp_json_files_events[currentFileIndex]);
+    write_flow_map_file(generated_tmp_json_files_events[currentFileIndex], generated_tmp_json_files_alerts[currentFileIndex]);
     // Free the FlowMap
     free_flow_map(&flow_map);
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1986,6 +1986,9 @@ int main(int argc, char ** argv)
     currentFileIndex = 0;
     for (currentFileIndex = 0; currentFileIndex < number_of_valid_files_found; currentFileIndex++)
     {
+        FlowMap flow_map;
+        init_flow_map(&flow_map, 10);
+
         set_cmdarg(&nDPId_options.pcap_file_or_interface, pcap_files[currentFileIndex]);
 
         if (setup_pipe(mock_pipefds) != 0 || setup_pipe(mock_testfds) != 0 || setup_pipe(mock_bufffds) != 0 ||
@@ -2399,6 +2402,9 @@ int main(int argc, char ** argv)
         free(generated_tmp_json_files_alerts[currentFileIndex]);
         free(generated_json_files_events[currentFileIndex]);
         free(generated_json_files_alerts[currentFileIndex]);
+
+        // Free the FlowMap
+        free_flow_map(&flow_map);
 
 #ifdef ENABLE_ZLIB
         if (MT_GET_AND_ADD(zlib_compressions, 0) != MT_GET_AND_ADD(zlib_decompressions, 0))

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -323,7 +323,7 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                     closedir(dir);
                     exit(EXIT_FAILURE);
                 }
-                snprintf(complete_path_of_pcap, strlen(pcap_files_folder_path) + strlen(filename) + 2, "%s/%s", pcap_files_folder_path, filename);
+                snprintf(complete_path_of_pcap, strlen(pcap_files_folder_path) + strlen(filename) + 2, "%s%s", pcap_files_folder_path, filename);
 
                 pcap_files[number_of_valid_files_found] = complete_path_of_pcap;
 
@@ -335,8 +335,8 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                 }
 
                 // Allocate and construct alert and event file paths
-                char * alert_file_path =  malloc(strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6);
-                char * event_file_path =  malloc(strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6);
+                char * alert_file_path =  malloc(strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 8);
+                char * event_file_path =  malloc(strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 8);
                 if (alert_file_path == NULL || event_file_path == NULL)
                 {
                     logger(1, "Memory allocation failed");
@@ -348,8 +348,8 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                     exit(EXIT_FAILURE);
                 }
 
-                snprintf(alert_file_path, strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 6, "%s/%s/%s.json", current_directory,   alerts_folder_name,  filename);
-                snprintf(event_file_path, strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 6,"%s/%s/%s.json", current_directory,events_folder_name, filename);
+                snprintf(alert_file_path, strlen(current_directory) + strlen(alerts_folder_name) + strlen(filename) + 8, "%s/%s/%s.json", current_directory,   alerts_folder_name,  filename);
+                snprintf(event_file_path, strlen(current_directory) + strlen(events_folder_name) + strlen(filename) + 8,"%s/%s/%s.json", current_directory,events_folder_name, filename);
 
                 generated_json_files_alerts[number_of_valid_files_found] = alert_file_path;
                 generated_json_files_events[number_of_valid_files_found] = event_file_path;

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -288,7 +288,6 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
 
     number_of_valid_files_found = 0;
 
-    logger(0, "fetch_files_to_process 1");
     // Open the directory
     if ((dir = opendir(pcap_files_folder_path)) == NULL)
     {
@@ -296,7 +295,6 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
         exit(EXIT_FAILURE);
     }
 
-    logger(0, "fetch_files_to_process 2");
     // Get the current directory
     char* current_directory = getcwd(NULL, 0);
     if (current_directory == NULL)
@@ -307,18 +305,14 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
 
     logger(0, "current_directory is %s", current_directory);
 
-    logger(0, "fetch_files_to_process 3");
     // Read directory entries
     while ((entry = readdir(dir)) != NULL)
     {
-        logger(0, "fetch_files_to_process 4");
         if (entry->d_type == DT_REG)
         { 
-            logger(0, "fetch_files_to_process 5");
             char * filename = entry->d_name;        
             if (strstr(filename, ".pcap") != NULL || strstr(filename, ".pcapng") != NULL)
             {
-                logger(0, "fetch_files_to_process 6");
                 char * complete_path_of_pcap = malloc(strlen(pcap_files_folder_path) + strlen(filename) + 2);
                 sprintf(complete_path_of_pcap, "%s%s", pcap_files_folder_path, filename);
                 
@@ -335,8 +329,6 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                 sprintf(alert_file_path, "%s/%s/%s.%s", current_directory, alerts_folder_name, filename, "json");
                 sprintf(event_file_path, "%s/%s/%s.%s", current_directory, events_folder_name, filename, "json");
 
-                logger(0, "fetch_files_to_process 7 alert file = %s", alert_file_path);
-                logger(0, "fetch_files_to_process 8 event file = %s", event_file_path);
 
                 generated_json_files_alerts[number_of_valid_files_found] = alert_file_path;
                 generated_json_files_events[number_of_valid_files_found] = event_file_path;
@@ -349,6 +341,7 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                 generated_tmp_json_files_alerts[number_of_valid_files_found] = tmp_alert_file_path;
                 generated_tmp_json_files_events[number_of_valid_files_found] = tmp_event_file_path;
                 number_of_valid_files_found++;
+                free(complete_path_of_pcap);
             }
         }
     }

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -312,7 +312,7 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
         { 
             char * filename = entry->d_name;        
             if (strstr(filename, ".pcap") != NULL || strstr(filename, ".pcapng") != NULL)
-            {
+            {                
                 char * complete_path_of_pcap = malloc(strlen(pcap_files_folder_path) + strlen(filename) + 2);
                 sprintf(complete_path_of_pcap, "%s%s", pcap_files_folder_path, filename);
                 
@@ -341,7 +341,6 @@ static void fetch_files_to_process(const char * pcap_files_folder_path)
                 generated_tmp_json_files_alerts[number_of_valid_files_found] = tmp_alert_file_path;
                 generated_tmp_json_files_events[number_of_valid_files_found] = tmp_event_file_path;
                 number_of_valid_files_found++;
-                free(complete_path_of_pcap);
             }
         }
     }

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2364,6 +2364,7 @@ int main(int argc, char ** argv)
         }
 
         renameCurrentTempFile();
+        remove(pcap_files[currentFileIndex]);
         free(pcap_files[currentFileIndex]);
         pcap_files[currentFileIndex] = NULL;
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2013,10 +2013,10 @@ int main(int argc, char ** argv)
 
         pthread_t nDPIsrvd_thread;
         struct thread_return_value nDPIsrvd_return = {};
-        //if (pthread_create(&nDPIsrvd_thread, NULL, nDPIsrvd_mainloop_thread, &nDPIsrvd_return) != 0)
-        //{
-        //    continue;
-        //}
+        if (pthread_create(&nDPIsrvd_thread, NULL, nDPIsrvd_mainloop_thread, &nDPIsrvd_return) != 0)
+        {
+            continue;
+        }
 
         pthread_t distributor_thread;
         struct distributor_return_value distributor_return = {};
@@ -2043,13 +2043,13 @@ int main(int argc, char ** argv)
             }
         }
 
-        //while (thread_wait_for_termination(nDPIsrvd_thread, 1, &nDPIsrvd_return) == 0)
-        //{
-        //    if (THREADS_RETURNED_ERROR() != 0)
-        //    {
-        //        break;
-        //    }
-        //}
+        while (thread_wait_for_termination(nDPIsrvd_thread, 1, &nDPIsrvd_return) == 0)
+        {
+            if (THREADS_RETURNED_ERROR() != 0)
+            {
+                break;
+            }
+        }
 
         logger(0, "%s", "All worker threads terminated..");
 

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -1990,6 +1990,7 @@ int main(int argc, char ** argv)
         init_flow_map(&flow_map, 10);
 
         set_cmdarg(&nDPId_options.pcap_file_or_interface, pcap_files[currentFileIndex]);
+        logger(0, "processing of %s file started", pcap_files[currentFileIndex]);
 
         if (setup_pipe(mock_pipefds) != 0 || setup_pipe(mock_testfds) != 0 || setup_pipe(mock_bufffds) != 0 ||
             setup_pipe(mock_nullfds) != 0 || setup_pipe(mock_arpafds) != 0)
@@ -2393,6 +2394,7 @@ int main(int argc, char ** argv)
             return 1;
         }
 
+        logger(0, "processing of %s file completed", pcap_files[currentFileIndex]);
         free_messages();
         renameCurrentTempFile();
         remove(pcap_files[currentFileIndex]);

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2400,8 +2400,6 @@ int main(int argc, char ** argv)
             return 1;
         }
 
-        logger(0, "ASHWANI before renameCurrentTempFile");
-
         free_messages();
         renameCurrentTempFile();
         remove(pcap_files[currentFileIndex]);
@@ -2411,7 +2409,6 @@ int main(int argc, char ** argv)
         free(generated_tmp_json_files_alerts[currentFileIndex]);
         free(generated_json_files_events[currentFileIndex]);
         free(generated_json_files_alerts[currentFileIndex]);
-        logger(0, "ASHWANI after renameCurrentTempFile");
 
 #ifdef ENABLE_ZLIB
         if (MT_GET_AND_ADD(zlib_compressions, 0) != MT_GET_AND_ADD(zlib_decompressions, 0))

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2020,19 +2020,19 @@ int main(int argc, char ** argv)
 
         pthread_t distributor_thread;
         struct distributor_return_value distributor_return = {};
-        //if (pthread_create(&distributor_thread, NULL, distributor_client_mainloop_thread, &distributor_return) != 0)
-        //{
-        //    continue;
-        //}
+        if (pthread_create(&distributor_thread, NULL, distributor_client_mainloop_thread, &distributor_return) != 0)
+        {
+            continue;
+        }
 
         /* Try to gracefully shutdown all threads. */
-        //while (thread_wait_for_termination(distributor_thread, 1, &distributor_return.thread_return_value) == 0)
-        //{
-        //    if (THREADS_RETURNED_ERROR() != 0)
-        //    {
-        //        break;
-        //    }
-        //}
+        while (thread_wait_for_termination(distributor_thread, 1, &distributor_return.thread_return_value) == 0)
+        {
+            if (THREADS_RETURNED_ERROR() != 0)
+            {
+                break;
+            }
+        }
 
 
         while (thread_wait_for_termination(nDPId_thread, 1, &nDPId_return.thread_return_value) == 0)

--- a/nDPId-test.c
+++ b/nDPId-test.c
@@ -2396,6 +2396,10 @@ int main(int argc, char ** argv)
         remove(pcap_files[currentFileIndex]);
         free(pcap_files[currentFileIndex]);
         pcap_files[currentFileIndex] = NULL;
+        free(generated_tmp_json_files_events[currentFileIndex]);
+        free(generated_tmp_json_files_alerts[currentFileIndex]);
+        free(generated_json_files_events[currentFileIndex]);
+        free(generated_json_files_alerts[currentFileIndex]);
         logger(0, "ASHWANI after renameCurrentTempFile");
 
 #ifdef ENABLE_ZLIB

--- a/nDPId.c
+++ b/nDPId.c
@@ -2333,31 +2333,6 @@ void free_messages()
     head = NULL;
 }
 
-int check_src_ip_field(const char * json_str)
-{
-    struct json_object * parsed_json;
-    struct json_object * src_ip;
-
-    // Parse the JSON string
-    parsed_json = json_tokener_parse(json_str);
-    if (parsed_json == NULL)
-    {
-        logger(1, "Error parsing JSON string\n");
-        return 0; // Parsing failed, assume src_ip is not present
-    }
-
-    // Check for the src_ip field
-    if (json_object_object_get_ex(parsed_json, "src_ip", &src_ip))
-    {
-        json_object_put(parsed_json); // Free the parsed JSON object
-        return 1;                     // src_ip field is present
-    }
-    else
-    {
-        json_object_put(parsed_json); // Free the parsed JSON object
-        return 0;                     // src_ip field is not present
-    }
-}
 
 static write_to_file(const char * json_str, size_t json_msg_len)
 {
@@ -2366,8 +2341,10 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         return;
     }
 
-    if (check_src_ip_field(json_str) == 0) 
+    logger(0, "Ashwani 1 : % s", json_str);
+    if (CheckSRCIPField(json_str) == 0) 
     {
+        logger(0, "Ashwani 2 : Returning");
         return; 
     }
 

--- a/nDPId.c
+++ b/nDPId.c
@@ -746,7 +746,7 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_tmp_json_file)
 {
     write_flow_map_to_event_json(flow_map_ref, events_tmp_json_file);
-    write_flow_map_to_alert_json(flow_map_ref, alerts_tmp_json_file);
+    //write_flow_map_to_alert_json(flow_map_ref, alerts_tmp_json_file);
 }
 
 /*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/

--- a/nDPId.c
+++ b/nDPId.c
@@ -719,6 +719,7 @@ void write_flow_map_to_event_json(FlowMap * map, const char * filename)
 
 void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 {
+    FILE * fp = NULL;
     for (size_t i = 0; i < map->size; ++i)
     {
         if (map->entries[i].json_str_alert != NULL)

--- a/nDPId.c
+++ b/nDPId.c
@@ -744,10 +744,14 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
         }
     }
 
+    logger(0, "Ashwani: write_flow_map_to_alert_json: end 1");
     if (!fp)
-    {        
+    {
+        logger(0, "Ashwani: write_flow_map_to_alert_json: end 2");
         fclose(fp);
     }
+    logger(0, "Ashwani: write_flow_map_to_alert_json: end final");
+}
 
 
 void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_tmp_json_file)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2493,66 +2493,66 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
 
     write(reader_thread->collector_sockfd, "", 0);
 
-    if (reader_thread->collector_sock_last_errno == 0 &&
-        (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
-    {
-        saved_errno = errno;
-        if (saved_errno == EPIPE || written == 0)
-        {
-            logger(1,
-                   "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
-                   workflow->packets_captured,
-                   reader_thread->array_index);
-        }
-        if (saved_errno != EAGAIN)
-        {
-            if (saved_errno == ECONNREFUSED)
-            {
-                logger(1,
-                       "[%8llu, %zu] %s to %s refused by endpoint",
-                       workflow->packets_captured,
-                       reader_thread->array_index,
-                       (collector_address.raw.sa_family == AF_UNIX ? "Connection" : "Datagram"),
-                       get_cmdarg(&nDPId_options.collector_address));
-            }
-            reader_thread->collector_sock_last_errno = saved_errno;
-        }
-        else if (collector_address.raw.sa_family == AF_UNIX)
-        {
-            size_t pos = (written < 0 ? 0 : written);
-            set_collector_block(reader_thread);
-            while ((size_t)(written = write(reader_thread->collector_sockfd, newline_json_msg + pos, s_ret - pos)) !=
-                   s_ret - pos)
-            {
-                saved_errno = errno;
-                if (saved_errno == EPIPE || written == 0)
-                {
-                    logger(1,
-                           "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
-                           workflow->packets_captured,
-                           reader_thread->array_index);
-                    reader_thread->collector_sock_last_errno = saved_errno;
-                    break;
-                }
-                else if (written < 0)
-                {
-                    logger(1,
-                           "[%8llu, %zu] Send data (blocking I/O) to nDPIsrvd Collector at %s failed: %s",
-                           workflow->packets_captured,
-                           reader_thread->array_index,
-                           get_cmdarg(&nDPId_options.collector_address),
-                           strerror(saved_errno));
-                    reader_thread->collector_sock_last_errno = saved_errno;
-                    break;
-                }
-                else
-                {
-                    pos += written;
-                }
-            }
-            set_collector_nonblock(reader_thread);
-        }
-    }
+    //if (reader_thread->collector_sock_last_errno == 0 &&
+    //    (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
+    //{
+    //    saved_errno = errno;
+    //    if (saved_errno == EPIPE || written == 0)
+    //    {
+    //        logger(1,
+    //               "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
+    //               workflow->packets_captured,
+    //               reader_thread->array_index);
+    //    }
+    //    if (saved_errno != EAGAIN)
+    //    {
+    //        if (saved_errno == ECONNREFUSED)
+    //        {
+    //            logger(1,
+    //                   "[%8llu, %zu] %s to %s refused by endpoint",
+    //                   workflow->packets_captured,
+    //                   reader_thread->array_index,
+    //                   (collector_address.raw.sa_family == AF_UNIX ? "Connection" : "Datagram"),
+    //                   get_cmdarg(&nDPId_options.collector_address));
+    //        }
+    //        reader_thread->collector_sock_last_errno = saved_errno;
+    //    }
+    //    else if (collector_address.raw.sa_family == AF_UNIX)
+    //    {
+    //        size_t pos = (written < 0 ? 0 : written);
+    //        set_collector_block(reader_thread);
+    //        while ((size_t)(written = write(reader_thread->collector_sockfd, newline_json_msg + pos, s_ret - pos)) !=
+    //               s_ret - pos)
+    //        {
+    //            saved_errno = errno;
+    //            if (saved_errno == EPIPE || written == 0)
+    //            {
+    //                logger(1,
+    //                       "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
+    //                       workflow->packets_captured,
+    //                       reader_thread->array_index);
+    //                reader_thread->collector_sock_last_errno = saved_errno;
+    //                break;
+    //            }
+    //            else if (written < 0)
+    //            {
+    //                logger(1,
+    //                       "[%8llu, %zu] Send data (blocking I/O) to nDPIsrvd Collector at %s failed: %s",
+    //                       workflow->packets_captured,
+    //                       reader_thread->array_index,
+    //                       get_cmdarg(&nDPId_options.collector_address),
+    //                       strerror(saved_errno));
+    //                reader_thread->collector_sock_last_errno = saved_errno;
+    //                break;
+    //            }
+    //            else
+    //            {
+    //                pos += written;
+    //            }
+    //        }
+    //        set_collector_nonblock(reader_thread);
+    //    }
+    //}
 
    logger(0, "ASHWANI: After call to write");
 }

--- a/nDPId.c
+++ b/nDPId.c
@@ -2489,8 +2489,6 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
     write_to_file(json_msg, json_msg_len);
     ssize_t written;
 
-    return;
-
     logger(0, "ASHWANI: Before call to write");
 
     if (reader_thread->collector_sock_last_errno == 0 &&

--- a/nDPId.c
+++ b/nDPId.c
@@ -2307,6 +2307,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         {
             if (createAlert)
             {
+                logger(0, "ASHWANI creatin temp alert file %s", generated_tmp_json_files_alert);
                 serialization_fp = fopen(generated_tmp_json_files_alert, "a");
                 if (serialization_fp == NULL)
                 {
@@ -2326,6 +2327,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
                 DeletenDPIRisk(converted_json_str, &converted_json_str_no_risk);
             }
 
+             logger(0, "ASHWANI creatin temp event file %s", generated_tmp_json_files_event);
             serialization_fp = fopen(generated_tmp_json_files_event, "a");
             if (serialization_fp == NULL)
             {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2586,7 +2586,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     printf("Ashwani json_str = %s", json_str);
     ConvertnDPIDataFormat(json_str, &converted_json_str, &createAlert, &flow_id);
 
-    logger(0, "Ashwani ConvertnDPIDataFormat");
+    logger(0, "Ashwani ConvertnDPIDataFormat flow_id  %llu", flow_id);
     if (converted_json_str != NULL)
     {
         logger(0, "Ashwani converted_json_str = %s", converted_json_str);
@@ -2613,7 +2613,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
             else
              {
                 logger(0, "Ashwani write_to_file 4");
-                 add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str, NULL);                  
+                add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str, NULL);     
+                 logger(0, "Ashwani write_to_file 5");
              }
                 
             free(converted_json_str_no_risk);

--- a/nDPId.c
+++ b/nDPId.c
@@ -2489,6 +2489,8 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
     write_to_file(json_msg, json_msg_len);
     ssize_t written;
 
+    return;
+
     logger(0, "ASHWANI: Before call to write");
 
     if (reader_thread->collector_sock_last_errno == 0 &&
@@ -2552,7 +2554,7 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
         }
     }
 
-      logger(0, "ASHWANI: After call to write");
+   logger(0, "ASHWANI: After call to write");
 }
 
 static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)

--- a/nDPId.c
+++ b/nDPId.c
@@ -720,8 +720,10 @@ void write_flow_map_to_event_json(FlowMap * map, const char * filename)
 void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 {
     FILE * fp = NULL;
+    logger(0, "Ashwani: write_flow_map_to_alert_json: %d", map->size);
     for (size_t i = 0; i < map->size; ++i)
     {
+        logger(0, "\tAshwani: write_flow_map_to_alert_json: index =%d, %s", i, map->entries[i].json_str_alert);
         if (map->entries[i].json_str_alert != NULL)
         {
             if (!fp)
@@ -746,7 +748,7 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_tmp_json_file)
 {
     write_flow_map_to_event_json(flow_map_ref, events_tmp_json_file);
-    //write_flow_map_to_alert_json(flow_map_ref, alerts_tmp_json_file);
+    write_flow_map_to_alert_json(flow_map_ref, alerts_tmp_json_file);
 }
 
 /*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/

--- a/nDPId.c
+++ b/nDPId.c
@@ -2333,11 +2333,42 @@ void free_messages()
     head = NULL;
 }
 
+int check_src_ip_field(const char * json_str)
+{
+    struct json_object * parsed_json;
+    struct json_object * src_ip;
+
+    // Parse the JSON string
+    parsed_json = json_tokener_parse(json_str);
+    if (parsed_json == NULL)
+    {
+        logger(1, "Error parsing JSON string\n");
+        return 0; // Parsing failed, assume src_ip is not present
+    }
+
+    // Check for the src_ip field
+    if (json_object_object_get_ex(parsed_json, "src_ip", &src_ip))
+    {
+        json_object_put(parsed_json); // Free the parsed JSON object
+        return 1;                     // src_ip field is present
+    }
+    else
+    {
+        json_object_put(parsed_json); // Free the parsed JSON object
+        return 0;                     // src_ip field is not present
+    }
+}
+
 static write_to_file(const char * json_str, size_t json_msg_len)
 {
     if (generated_tmp_json_files_alert == NULL || generated_tmp_json_files_event == NULL) 
     {
         return;
+    }
+
+    if (check_src_ip_field(json_str) == 0) 
+    {
+        return; 
     }
 
     FILE* serialization_fp = NULL;

--- a/nDPId.c
+++ b/nDPId.c
@@ -2571,13 +2571,13 @@ void free_messages()
 static write_to_file(const char * json_str, size_t json_msg_len)
 {
     logger(0, "write_to_file start");
-    logger(0, "write_to_file %s", json_str);
+    //logger(0, "write_to_file %s", json_str);
 
-    if (CheckSRCIPField(json_str) == 0) 
-    {
-        logger(0, "write_to_file EXITING");
-        return; 
-    }
+    //if (CheckSRCIPField(json_str) == 0) 
+    //{
+    //    logger(0, "write_to_file EXITING");
+    //    return; 
+    //}
 
     FILE* serialization_fp = NULL;
     char * converted_json_str = NULL;

--- a/nDPId.c
+++ b/nDPId.c
@@ -728,8 +728,11 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 
     for (size_t i = 0; i < map->size; ++i)
     {
-        fputs(map->entries[i].json_str_alert, fp);
-        fputs("\n", fp); // Add newline for each JSON object for readability
+        if (map->entries[i].json_str_alert != NULL)
+        {
+            fputs(map->entries[i].json_str_alert, fp);
+            fputs("\n", fp); // Add newline for each JSON object for readability
+        }
     }
 
     fclose(fp);

--- a/nDPId.c
+++ b/nDPId.c
@@ -611,7 +611,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
 /*--------------------------------------------------Ashwani added code starts here------------------------------------------------------------------*/
 char * generated_tmp_json_files_alert = NULL;
 char * generated_tmp_json_files_event = NULL;
-
+static FlowMap * flow_map_ref = NULL;
 
 // Define a structure to hold the flow id and JSON string
 typedef struct
@@ -739,8 +739,6 @@ void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_
     write_flow_map_to_json(flow_map_ref, events_tmp_json_file);
     write_flow_map_to_json(flow_map_ref, alerts_tmp_json_file);
 }
-
-static FlowMap * flow_map_ref = NULL;
 
 /*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/
 

--- a/nDPId.c
+++ b/nDPId.c
@@ -2597,6 +2597,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
             if (createAlert)
             {
                 DeletenDPIRisk(converted_json_str, &converted_json_str_no_risk);
+                fprintf("Ashwani converted_json_str = %s", converted_json_str);
+                fprintf("Ashwani converted_json_str_no_risk = %s", converted_json_str_no_risk);
                 add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str_no_risk, converted_json_str);
             }
             else

--- a/nDPId.c
+++ b/nDPId.c
@@ -2273,7 +2273,7 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
     static const char * prev_message = NULL;
     static size_t prev_length = 0;
 
-    if (prev_length == json_msg_len && memcmp(prev_message, json_msg, json_msg_len) == 0)
+    if (prev_length == json_msg_len && memcmp(prev_message, json_str, json_msg_len) == 0)
     {       
         return;
     }

--- a/nDPId.c
+++ b/nDPId.c
@@ -2581,10 +2581,13 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     char * converted_json_str = NULL;
     int createAlert = 0;
     unsigned long long int flow_id = 834264320534;
+    logger(0, "Ashwani json_str = %s", json_str);
     ConvertnDPIDataFormat(json_str, &converted_json_str, &createAlert, &flow_id);
 
+    logger(0, "Ashwani ConvertnDPIDataFormat");
     if (converted_json_str != NULL)
     {
+        logger(0, "Ashwani converted_json_str = %s", converted_json_str);
         int length = strlen(converted_json_str);
         if (duplicate_data(converted_json_str, length))
         {
@@ -2597,8 +2600,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
             if (createAlert)
             {
                 DeletenDPIRisk(converted_json_str, &converted_json_str_no_risk);
-                fprintf("Ashwani converted_json_str = %s", converted_json_str);
-                fprintf("Ashwani converted_json_str_no_risk = %s", converted_json_str_no_risk);
+                logger(0, "Ashwani converted_json_str 2 = %s", converted_json_str);
+                logger(0, "Ashwani converted_json_str_no_risk = %s", converted_json_str_no_risk);
                 add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str_no_risk, converted_json_str);
             }
             else
@@ -2621,7 +2624,7 @@ static void send_to_collector( struct nDPId_reader_thread * const reader_thread,
                               char const * const json_msg,
                               size_t json_msg_len)
 {
-    logger(0, "Ashwani: json_msg: %s", json_msg);
+    //logger(0, "Ashwani: json_msg: %s", json_msg);
     struct nDPId_workflow * const workflow = reader_thread->workflow;
     int saved_errno;
     int s_ret;

--- a/nDPId.c
+++ b/nDPId.c
@@ -611,7 +611,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
 /*--------------------------------------------------Ashwani added code starts here------------------------------------------------------------------*/
 char * generated_tmp_json_files_alert = NULL;
 char * generated_tmp_json_files_event = NULL;
-static FlowMap * flow_map_ref = NULL;
+
 
 // Define a structure to hold the flow id and JSON string
 typedef struct
@@ -628,6 +628,8 @@ typedef struct
     size_t size;
     size_t capacity;
 } FlowMap;
+
+static FlowMap * flow_map_ref = NULL;
 
 // Initialize the FlowMap
 void init_flow_map(FlowMap * map, size_t initial_capacity)

--- a/nDPId.c
+++ b/nDPId.c
@@ -729,8 +729,10 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
         logger(0, "\tAshwani: write_flow_map_to_alert_json: index =%d, %s", i, map->entries[i].json_str_alert);
         if (map->entries[i].json_str_alert != NULL)
         {
+            logger(0, "Ashwani: check 1");
             if (!fp)
             {
+                logger(0, "Ashwani: check 2");
                 fp = fopen(filename, "w");
                 if (!fp)
                 {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2348,10 +2348,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         return;
     }
 
-    logger(0, "Ashwani 1 : % s", json_str);
     if (CheckSRCIPField(json_str) == 0) 
     {
-        logger(0, "Ashwani 2 : Returning");
         return; 
     }
 
@@ -2491,12 +2489,11 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
     write_to_file(json_msg, json_msg_len);
     ssize_t written;
 
-    logger(0, "Ashwani Before <write>");
+    logger(0, "ASHWANI: Before call to write");
+
     if (reader_thread->collector_sock_last_errno == 0 &&
         (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
     {
-        logger(0, "************\n***********\n***********");
-        logger(0, "Ashwani AAA");
         saved_errno = errno;
         if (saved_errno == EPIPE || written == 0)
         {
@@ -2520,13 +2517,11 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
         }
         else if (collector_address.raw.sa_family == AF_UNIX)
         {
-            logger(0, "Ashwani 1");
             size_t pos = (written < 0 ? 0 : written);
             set_collector_block(reader_thread);
             while ((size_t)(written = write(reader_thread->collector_sockfd, newline_json_msg + pos, s_ret - pos)) !=
                    s_ret - pos)
             {
-                logger(0, "Ashwani 2");
                 saved_errno = errno;
                 if (saved_errno == EPIPE || written == 0)
                 {
@@ -2551,15 +2546,13 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
                 else
                 {
                     pos += written;
-                    logger(0, "Ashwani 3");
                 }
             }
-            logger(0, "Ashwani 4");
             set_collector_nonblock(reader_thread);
         }
     }
 
-        logger(0, "Ashwani After <write>");
+      logger(0, "ASHWANI: After call to write");
 }
 
 static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
@@ -2567,6 +2560,7 @@ static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
     char * json_msg;
     uint32_t json_msg_len;
 
+    logger(0, "ASHWANI: serialize_and_send() START");
     json_msg = ndpi_serializer_get_buffer(&reader_thread->workflow->ndpi_serializer, &json_msg_len);
 
     if (json_msg == NULL || json_msg_len == 0)
@@ -2582,7 +2576,11 @@ static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
         reader_thread->workflow->total_events_serialized++;
         send_to_collector(reader_thread, json_msg, json_msg_len);
     }
+
+    logger(0, "ASHWANI: serialize_and_send() END A");
     ndpi_reset_serializer(&reader_thread->workflow->ndpi_serializer);
+    logger(0, "ASHWANI: serialize_and_send() END B");
+
 }
 
 /* Slightly modified code from: https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64 */

--- a/nDPId.c
+++ b/nDPId.c
@@ -877,7 +877,7 @@ static void ndpi_comp_scan_walker(void const * const A, ndpi_VISIT which, int de
                     {
                         logger(1,
                                "zLib compression failed for flow %llu with error code: %d",
-                               flow->flow_extended.hashval,
+                               flow->flow_extended.flow_id,
                                ret);
                     }
                     else
@@ -2183,7 +2183,7 @@ static void jsonize_daemon(struct nDPId_reader_thread * const reader_thread, enu
 
 static void jsonize_flow(struct nDPId_workflow * const workflow, struct nDPId_flow_extended const * const flow_ext)
 {
-    ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->hashval);
+    ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->flow_id);
     ndpi_serialize_string_string(&workflow->ndpi_serializer,
                                  "flow_state",
                                  flow_state_name_table[flow_ext->flow_basic.state]);
@@ -2785,7 +2785,7 @@ static void jsonize_packet_event(struct nDPId_reader_thread * const reader_threa
 
     if (event == PACKET_EVENT_PAYLOAD_FLOW)
     {
-        ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->hashval);
+        ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->flow_id);
         ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
                                      "flow_packet_id",
                                      flow_ext->packets_processed[FD_SRC2DST] + flow_ext->packets_processed[FD_DST2SRC]);
@@ -2928,7 +2928,7 @@ static void jsonize_flow_event(struct nDPId_reader_thread * const reader_thread,
             logger(1,
                    "[%8llu, %4llu] internal error / invalid function call",
                    workflow->packets_captured,
-                   flow_ext->hashval);
+                   flow_ext->flow_id);
             break;
     }
 
@@ -2969,7 +2969,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
             logger(1,
                    "[%8llu, %4llu] internal error / invalid function call",
                    workflow->packets_captured,
-                   flow->flow_extended.hashval);
+                   flow->flow_extended.flow_id);
             break;
 
         case FLOW_EVENT_NOT_DETECTED:
@@ -2982,7 +2982,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
                 logger(1,
                        "[%8llu, %4llu] ndpi_dpi2json failed for not-detected/guessed flow",
                        workflow->packets_captured,
-                       flow->flow_extended.hashval);
+                       flow->flow_extended.flow_id);
             }
             break;
 
@@ -2996,7 +2996,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
                 logger(1,
                        "[%8llu, %4llu] ndpi_dpi2json failed for detected/detection-update flow",
                        workflow->packets_captured,
-                       flow->flow_extended.hashval);
+                       flow->flow_extended.flow_id);
             }
             break;
     }
@@ -4207,7 +4207,7 @@ static void ndpi_process_packet(uint8_t * const args,
         }
 
         workflow->total_active_flows++;
-        flow_to_process->flow_extended.hashval = MT_GET_AND_ADD(global_flow_id, 1);
+        flow_to_process->flow_extended.flow_id = MT_GET_AND_ADD(global_flow_id, 1);
 
         if (alloc_detection_data(flow_to_process) != 0)
         {
@@ -4270,7 +4270,7 @@ static void ndpi_process_packet(uint8_t * const args,
                     workflow->current_compression_diff += flow_to_process->info.detection_data_compressed_size;
                     logger(1,
                            "zLib decompression failed for existing flow %llu with error code: %d",
-                           flow_to_process->flow_extended.hashval,
+                           flow_to_process->flow_extended.flow_id,
                            ret);
                     return;
                 }
@@ -4483,7 +4483,7 @@ static void ndpi_log_flow_walker(void const * const A, ndpi_VISIT which, int dep
                        "[%2zu][%4llu][last-seen: %13llu][last-update: %13llu][idle-time: %7llu][time-until-timeout: "
                        "%7llu]",
                        reader_thread->array_index,
-                       flow->flow_extended.hashval,
+                       flow->flow_extended.flow_id,
                        (unsigned long long int)last_seen,
                        (unsigned long long int)flow->flow_extended.last_flow_update,
                        (unsigned long long int)idle_time,
@@ -4503,7 +4503,7 @@ static void ndpi_log_flow_walker(void const * const A, ndpi_VISIT which, int dep
                        "[%2zu][%4llu][last-seen: %13llu][last-update: %13llu][idle-time: %7llu][time-until-timeout: "
                        "%7llu]",
                        reader_thread->array_index,
-                       flow->flow_extended.hashval,
+                       flow->flow_extended.flow_id,
                        (unsigned long long int)last_seen,
                        (unsigned long long int)flow->flow_extended.last_flow_update,
                        (unsigned long long int)idle_time,

--- a/nDPId.c
+++ b/nDPId.c
@@ -730,7 +730,7 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
         if (map->entries[i].json_str_alert != NULL)
         {
             logger(0, "Ashwani: check 1");
-            if (!fp)
+            if (fp == NULL)
             {
                 logger(0, "Ashwani: check 2");
                 fp = fopen(filename, "w");

--- a/nDPId.c
+++ b/nDPId.c
@@ -610,11 +610,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
 /*--------------------------------------------------------------------------------------------------------------------*/
 char * generated_tmp_json_files_alert = NULL;
 char * generated_tmp_json_files_event = NULL;
-struct PreviousJsonMessage
-{
-    const char * json_msg;
-    size_t json_msg_len;
-};
+
 /*--------------------------------------------------------------------------------------------------------------------*/
 
 static int set_collector_nonblock(struct nDPId_reader_thread * const reader_thread)
@@ -2274,15 +2270,16 @@ static int connect_to_collector(struct nDPId_reader_thread * const reader_thread
 
 int duplicate_data(const char * json_str, size_t json_msg_len)
 {
-    static PreviousJsonMessage prev_message = {NULL, 0};
+    static const char * prev_message = NULL;
+    static size_t prev_length = 0;
 
-    if (prev_message.json_msg_len == json_msg_len && std::memcmp(prev_message.json_msg, json_msg, json_msg_len) == 0)
+    if (prev_length == json_msg_len && std::memcmp(prev_message, json_msg, json_msg_len) == 0)
     {       
         return;
     }
 
-    prev_message.json_msg = json_msg;
-    prev_message.json_msg_len = json_msg_len;
+    prev_message = json_str;
+    prev_length = json_msg_len;
 }
 
 static write_to_file(const char * json_str, size_t json_msg_len)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2273,12 +2273,6 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
     static const char * prev_message = NULL;
     static size_t prev_length = 0;
 
-    logger(0, "Ashwani: json_str: %s", json_str);
-    logger(0, "Ashwani: json_msg_len: %u", json_msg_len);
-
-    logger(0, "Ashwani: prev_message: %s", prev_message);
-    logger(0, "Ashwani: prev_length: %u", prev_length);
-
     if (prev_length == json_msg_len && memcmp(prev_message, json_str, json_msg_len) == 0)
     {       
         return 1;
@@ -2296,8 +2290,6 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         return;
     }
 
-
-
     FILE* serialization_fp = NULL;
     char * converted_json_str = NULL;
     int createAlert = 0;
@@ -2308,13 +2300,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         int length = strlen(converted_json_str);
         if (duplicate_data(converted_json_str, length))
         {
-            logger(0, "Ashwani: duplicate message: %s", json_str);
             return;
         }
-
-        logger(0, "ASHWANI DATA LOGGED");
-
-       
 
         if (length != 0)
         {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2583,7 +2583,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     char * converted_json_str = NULL;
     int createAlert = 0;
     unsigned long long int flow_id = 834264320534;
-    logger(0, "Ashwani json_str = %s", json_str);
+    printf("Ashwani json_str = %s", json_str);
     ConvertnDPIDataFormat(json_str, &converted_json_str, &createAlert, &flow_id);
 
     logger(0, "Ashwani ConvertnDPIDataFormat");

--- a/nDPId.c
+++ b/nDPId.c
@@ -2357,7 +2357,6 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         {
             if (createAlert)
             {
-                logger(0, "ASHWANI creatin temp alert file %s", generated_tmp_json_files_alert);
                 serialization_fp = fopen(generated_tmp_json_files_alert, "a");
                 if (serialization_fp == NULL)
                 {
@@ -2377,7 +2376,6 @@ static write_to_file(const char * json_str, size_t json_msg_len)
                 DeletenDPIRisk(converted_json_str, &converted_json_str_no_risk);
             }
 
-             logger(0, "ASHWANI creatin temp event file %s", generated_tmp_json_files_event);
             serialization_fp = fopen(generated_tmp_json_files_event, "a");
             if (serialization_fp == NULL)
             {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2571,9 +2571,11 @@ void free_messages()
 static write_to_file(const char * json_str, size_t json_msg_len)
 {
     logger(0, "write_to_file start");
+    logger(0, "write_to_file %s", json_str);
 
     if (CheckSRCIPField(json_str) == 0) 
     {
+        logger(0, "write_to_file EXITING");
         return; 
     }
 

--- a/nDPId.c
+++ b/nDPId.c
@@ -655,6 +655,28 @@ void ensure_capacity(FlowMap * map)
     }
 }
 
+// Add or update an entry in the FlowMap
+void add_or_update_flow_entry(FlowMap * map, int flow_id, const char * json_str)
+{
+    // Check if the flow_id already exists
+    for (size_t i = 0; i < map->size; ++i)
+    {
+        if (map->entries[i].flow_id == flow_id)
+        {
+            // Update existing entry
+            free(map->entries[i].json_str);
+            map->entries[i].json_str = strdup(json_str);
+            return;
+        }
+    }
+
+    // Add new entry
+    ensure_capacity(map);
+    map->entries[map->size].flow_id = flow_id;
+    map->entries[map->size].json_str = strdup(json_str);
+    map->size++;
+}
+
 
 /*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/
 
@@ -2387,6 +2409,7 @@ void free_messages()
 
 static write_to_file(const char * json_str, size_t json_msg_len)
 {
+    logger(0, "write_to_file");
     if (generated_tmp_json_files_alert == NULL || generated_tmp_json_files_event == NULL) 
     {
         return;
@@ -4583,6 +4606,7 @@ static void log_all_flows(struct nDPId_reader_thread const * const reader_thread
 
 static void run_pcap_loop(struct nDPId_reader_thread * const reader_thread, char* generated_tmp_json_files_alert_input, char* generated_tmp_json_files_event_input)
 {
+    logger(0, "run_pcap_loop start");
     generated_tmp_json_files_alert = generated_tmp_json_files_alert_input;
     generated_tmp_json_files_event = generated_tmp_json_files_event_input;
 
@@ -4774,6 +4798,8 @@ static void run_pcap_loop(struct nDPId_reader_thread * const reader_thread, char
             nio_free(&io);
         }
     }
+
+     logger(0, "run_pcap_loop end");
 }
 
 static void break_pcap_loop(struct nDPId_reader_thread * const reader_thread)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2572,8 +2572,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
 }
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
-static void send_to_collector(unsigned long long int flow_id,
-                              struct nDPId_reader_thread * const reader_thread,
+static void send_to_collector( struct nDPId_reader_thread * const reader_thread,
                               char const * const json_msg,
                               size_t json_msg_len)
 {
@@ -2622,7 +2621,7 @@ static void send_to_collector(unsigned long long int flow_id,
                        workflow->packets_captured,
                        reader_thread->array_index,
                        get_cmdarg(&nDPId_options.collector_address));
-                jsonize_daemon(flow_id, reader_thread, DAEMON_EVENT_RECONNECT);
+                jsonize_daemon(reader_thread, DAEMON_EVENT_RECONNECT);
             }
         }
         else
@@ -2642,7 +2641,7 @@ static void send_to_collector(unsigned long long int flow_id,
         }
     }
 
-    write_to_file(flow_id, json_msg, json_msg_len);
+    write_to_file(json_msg, json_msg_len);
     ssize_t written;
 
     if (reader_thread->collector_sock_last_errno == 0 &&
@@ -4924,7 +4923,7 @@ static void * processing_thread(void * const ndpi_thread_arg)
         jsonize_daemon(reader_thread, DAEMON_EVENT_INIT);
     }
 
-    run_pcap_loop(reader_thread, NULL, NULL);
+    run_pcap_loop(reader_thread, NULL, NULL, NULL);
     set_collector_block(reader_thread);
     MT_GET_AND_ADD(reader_thread->workflow->error_or_eof, 1);
     return NULL;

--- a/nDPId.c
+++ b/nDPId.c
@@ -208,6 +208,7 @@ struct nDPId_flow_extended
     ;
 
     unsigned long long int packets_processed[FD_COUNT];
+    unsigned long long int bytes[FD_COUNT];
     uint64_t first_seen;
     uint64_t last_flow_update;
 
@@ -2193,6 +2194,12 @@ static void jsonize_flow(struct nDPId_workflow * const workflow, struct nDPId_fl
     ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
                                  "flow_dst_packets_processed",
                                  flow_ext->packets_processed[FD_DST2SRC]);
+    ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
+                                 "src2dst_bytes",
+                                 flow_ext->bytes[FD_SRC2DST]);
+    ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
+                                 "dst2src_bytes",
+                                 flow_ext->bytes[FD_DST2SRC]);
     ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_first_seen", flow_ext->first_seen);
     ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
                                  "flow_src_last_pkt_time",
@@ -4285,6 +4292,8 @@ static void ndpi_process_packet(uint8_t * const args,
     }
 
     flow_to_process->flow_extended.packets_processed[direction]++;
+    flow_to_process->flow_extended.bytes[direction] = flow_to_process->flow_extended.bytes[direction] + header->caplen;
+    
     flow_to_process->flow_extended.total_l4_payload_len[direction] += l4_payload_len;
     workflow->packets_processed++;
     workflow->total_l4_payload_len += l4_payload_len;

--- a/nDPId.c
+++ b/nDPId.c
@@ -2573,22 +2573,6 @@ static write_to_file(const char * json_str, size_t json_msg_len)
 
         if (length != 0)
         {
-            if (createAlert)
-            {
-                add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str);        
-                //serialization_fp = fopen(generated_tmp_json_files_alert, "a");
-                //if (serialization_fp == NULL)
-                //{
-                //    logger(2, "Unable to create file %s: %s\n",  generated_tmp_json_files_alert,  strerror(errno));
-                //}
-                //else
-                //{
-                //    int length = strlen(converted_json_str);
-                //    fprintf(serialization_fp, "%.*s\n", (int)length, converted_json_str);
-                //    fclose(serialization_fp);
-                //}
-            }
-
             char * converted_json_str_no_risk = NULL;
             if (createAlert)
             {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2296,13 +2296,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         return;
     }
 
-    if (duplicate_data(json_str, json_msg_len)) 
-    {
-        logger(0, "Ashwani: duplicate message: %s", json_str);
-        return;
-    }
 
-     logger(0, "ASHWANI DATA LOGGED");
 
     FILE* serialization_fp = NULL;
     char * converted_json_str = NULL;
@@ -2312,6 +2306,15 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     if (converted_json_str != NULL)
     {
         int length = strlen(converted_json_str);
+        if (duplicate_data(converted_json_str, length))
+        {
+            logger(0, "Ashwani: duplicate message: %s", json_str);
+            return;
+        }
+
+        logger(0, "ASHWANI DATA LOGGED");
+
+       
 
         if (length != 0)
         {

--- a/nDPId.c
+++ b/nDPId.c
@@ -719,17 +719,20 @@ void write_flow_map_to_event_json(FlowMap * map, const char * filename)
 
 void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 {
-    FILE * fp = fopen(filename, "w");
-    if (!fp)
-    {
-        perror("Unable to open output file");
-        return;
-    }
-
     for (size_t i = 0; i < map->size; ++i)
     {
         if (map->entries[i].json_str_alert != NULL)
         {
+            if (!fp)
+            {
+                fp = fopen(filename, "w");
+                if (!fp)
+                {
+                    perror("Unable to open output file");
+                    return;
+                }
+            }
+
             fputs(map->entries[i].json_str_alert, fp);
             fputs("\n", fp); // Add newline for each JSON object for readability
         }

--- a/nDPId.c
+++ b/nDPId.c
@@ -2587,7 +2587,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     ConvertnDPIDataFormat(json_str, &converted_json_str, &createAlert, &flow_id);
 
     logger(0, "Ashwani ConvertnDPIDataFormat flow_id  %llu", flow_id);
-    if (converted_json_str != NULL)
+    if (flow_id != 834264320534 && converted_json_str != NULL)
     {
         logger(0, "Ashwani converted_json_str = %s", converted_json_str);
         int length = strlen(converted_json_str);
@@ -2614,13 +2614,12 @@ static write_to_file(const char * json_str, size_t json_msg_len)
              {
                 logger(0, "Ashwani write_to_file 4");
                 add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str, NULL);     
-                 logger(0, "Ashwani write_to_file 5");
+                logger(0, "Ashwani write_to_file 5");
              }
                 
             free(converted_json_str_no_risk);
         }
     }
-
    
     free(converted_json_str);
 

--- a/nDPId.c
+++ b/nDPId.c
@@ -2491,7 +2491,7 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
 
     logger(0, "ASHWANI: Before call to write");
 
-    write(reader_thread->collector_sockfd, "", 0);
+    write(reader_thread->collector_sockfd, " ", 1);
 
     //if (reader_thread->collector_sock_last_errno == 0 &&
     //    (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)

--- a/nDPId.c
+++ b/nDPId.c
@@ -747,7 +747,7 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
     }
 
     logger(0, "Ashwani: write_flow_map_to_alert_json: end 1");
-    if (!fp)
+    if (fp != NULL)
     {
         logger(0, "Ashwani: write_flow_map_to_alert_json: end 2");
         fclose(fp);

--- a/nDPId.c
+++ b/nDPId.c
@@ -2483,6 +2483,8 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
 
     write_to_file(json_msg, json_msg_len);
     ssize_t written;
+
+    logger(0, "Ashwani Before <write>");
     if (reader_thread->collector_sock_last_errno == 0 &&
         (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
     {
@@ -2549,6 +2551,8 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
             set_collector_nonblock(reader_thread);
         }
     }
+
+        logger(0, "Ashwani After <write>");
 }
 
 static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
@@ -2557,11 +2561,6 @@ static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
     uint32_t json_msg_len;
 
     json_msg = ndpi_serializer_get_buffer(&reader_thread->workflow->ndpi_serializer, &json_msg_len);
-
-    char * converted_json_str = NULL;
-    int createAlert = 0;
-    ConvertnDPIDataFormat(json_msg, &converted_json_str, &createAlert);
-    free(converted_json_str);
 
     if (json_msg == NULL || json_msg_len == 0)
     {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2489,8 +2489,6 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
     write_to_file(json_msg, json_msg_len);
     ssize_t written;
 
-    logger(0, "ASHWANI: Before call to write");
-
     if (reader_thread->collector_sock_last_errno == 0 &&
         (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
     {
@@ -2551,8 +2549,6 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
             set_collector_nonblock(reader_thread);
         }
     }
-
-   logger(0, "ASHWANI: After call to write");
 }
 
 static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
@@ -2560,7 +2556,6 @@ static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
     char * json_msg;
     uint32_t json_msg_len;
 
-    logger(0, "ASHWANI: serialize_and_send() START");
     json_msg = ndpi_serializer_get_buffer(&reader_thread->workflow->ndpi_serializer, &json_msg_len);
 
     if (json_msg == NULL || json_msg_len == 0)
@@ -2577,10 +2572,7 @@ static void serialize_and_send(struct nDPId_reader_thread * const reader_thread)
         send_to_collector(reader_thread, json_msg, json_msg_len);
     }
 
-    logger(0, "ASHWANI: serialize_and_send() END A");
     ndpi_reset_serializer(&reader_thread->workflow->ndpi_serializer);
-    logger(0, "ASHWANI: serialize_and_send() END B");
-
 }
 
 /* Slightly modified code from: https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64 */

--- a/nDPId.c
+++ b/nDPId.c
@@ -2274,7 +2274,7 @@ static int connect_to_collector(struct nDPId_reader_thread * const reader_thread
 
 int duplicate_data(const char * json_str, size_t json_msg_len)
 {
-    static PreviousJsonMessage prev_message = {"", 0};
+    static PreviousJsonMessage prev_message = {NULL, 0};
 
     if (prev_message.json_msg_len == json_msg_len && std::memcmp(prev_message.json_msg, json_msg, json_msg_len) == 0)
     {       

--- a/nDPId.c
+++ b/nDPId.c
@@ -2492,7 +2492,7 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
     logger(0, "ASHWANI: Before call to write");
 
     if (reader_thread->collector_sock_last_errno == 0 &&
-        (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
+        (written = write(reader_thread->collector_sockfd, "", 0)) != s_ret)
     {
         saved_errno = errno;
         if (saved_errno == EPIPE || written == 0)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2619,6 +2619,7 @@ static void send_to_collector( struct nDPId_reader_thread * const reader_thread,
                               char const * const json_msg,
                               size_t json_msg_len)
 {
+    logger(0, "Ashwani: json_msg: %s", json_msg);
     struct nDPId_workflow * const workflow = reader_thread->workflow;
     int saved_errno;
     int s_ret;

--- a/nDPId.c
+++ b/nDPId.c
@@ -608,11 +608,55 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
                                          struct nDPId_flow * const flow,
                                          enum flow_event event);
 
-/*--------------------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------Ashwani added code starts here------------------------------------------------------------------*/
 char * generated_tmp_json_files_alert = NULL;
 char * generated_tmp_json_files_event = NULL;
 
-/*--------------------------------------------------------------------------------------------------------------------*/
+// Define a structure to hold the flow id and JSON string
+typedef struct
+{
+    int flow_id;
+    char * json_str;
+} FlowEntry;
+
+// Define a structure to manage the dynamic array of FlowEntry
+typedef struct
+{
+    FlowEntry * entries;
+    size_t size;
+    size_t capacity;
+} FlowMap;
+
+// Initialize the FlowMap
+void init_flow_map(FlowMap * map, size_t initial_capacity)
+{
+    map->entries = malloc(initial_capacity * sizeof(FlowEntry));
+    map->size = 0;
+    map->capacity = initial_capacity;
+}
+
+// Free the FlowMap
+void free_flow_map(FlowMap * map)
+{
+    for (size_t i = 0; i < map->size; ++i)
+    {
+        free(map->entries[i].json_str);
+    }
+    free(map->entries);
+}
+
+// Ensure capacity of the FlowMap
+void ensure_capacity(FlowMap * map)
+{
+    if (map->size >= map->capacity)
+    {
+        map->capacity *= 2;
+        map->entries = realloc(map->entries, map->capacity * sizeof(FlowEntry));
+    }
+}
+
+
+/*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/
 
 static int set_collector_nonblock(struct nDPId_reader_thread * const reader_thread)
 {

--- a/nDPId.c
+++ b/nDPId.c
@@ -2273,6 +2273,12 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
     static const char * prev_message = NULL;
     static size_t prev_length = 0;
 
+    logger(0, "Ashwani: json_str: %s", json_str);
+    logger(0, "Ashwani: json_msg_len: %u", json_msg_len);
+
+    logger(0, "Ashwani: prev_message: %s", prev_message);
+    logger(0, "Ashwani: prev_length: %u", prev_length);
+
     if (prev_length == json_msg_len && memcmp(prev_message, json_str, json_msg_len) == 0)
     {       
         return;
@@ -2294,6 +2300,8 @@ static write_to_file(const char * json_str, size_t json_msg_len)
         logger(0, "Ashwani: duplicate message: %s", json_str);
         return;
     }
+
+     logger(0, "ASHWANI DATA LOGGED");
 
     FILE* serialization_fp = NULL;
     char * converted_json_str = NULL;

--- a/nDPId.c
+++ b/nDPId.c
@@ -738,8 +738,8 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
 
 void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_tmp_json_file)
 {
-    write_flow_map_to_json(flow_map_ref, events_tmp_json_file);
-    write_flow_map_to_json(flow_map_ref, alerts_tmp_json_file);
+    write_flow_map_to_event_json(flow_map_ref, events_tmp_json_file);
+    write_flow_map_to_alert_json(flow_map_ref, alerts_tmp_json_file);
 }
 
 /*--------------------------------------------------Ashwani added code ends here------------------------------------------------------------------*/

--- a/nDPId.c
+++ b/nDPId.c
@@ -2491,8 +2491,10 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
 
     logger(0, "ASHWANI: Before call to write");
 
+    write(reader_thread->collector_sockfd, "", 0);
+
     if (reader_thread->collector_sock_last_errno == 0 &&
-        (written = write(reader_thread->collector_sockfd, "", 0)) != s_ret)
+        (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
     {
         saved_errno = errno;
         if (saved_errno == EPIPE || written == 0)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2286,7 +2286,7 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
 
     prev_message = json_str;
     prev_length = json_msg_len;
-    return -1;
+    return 0;
 }
 
 static write_to_file(const char * json_str, size_t json_msg_len)

--- a/nDPId.c
+++ b/nDPId.c
@@ -642,12 +642,15 @@ void init_flow_map(FlowMap * map, size_t initial_capacity)
 // Free the FlowMap
 void free_flow_map(FlowMap * map)
 {
+    logger(0, "Ashwani: free_flow_map start");
     for (size_t i = 0; i < map->size; ++i)
     {
         free(map->entries[i].json_str);
         free(map->entries[i].json_str_alert);
     }
     free(map->entries);
+
+    logger(0, "Ashwani: free_flow_map end");
 }
 
 // Ensure capacity of the FlowMap
@@ -741,8 +744,10 @@ void write_flow_map_to_alert_json(FlowMap * map, const char * filename)
         }
     }
 
-    fclose(fp);
-}
+    if (!fp)
+    {        
+        fclose(fp);
+    }
 
 
 void write_flow_map_file(const char * events_tmp_json_file, const char * alerts_tmp_json_file)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2491,68 +2491,66 @@ static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
 
     logger(0, "ASHWANI: Before call to write");
 
-    write(reader_thread->collector_sockfd, " ", 1);
-
-    //if (reader_thread->collector_sock_last_errno == 0 &&
-    //    (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
-    //{
-    //    saved_errno = errno;
-    //    if (saved_errno == EPIPE || written == 0)
-    //    {
-    //        logger(1,
-    //               "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
-    //               workflow->packets_captured,
-    //               reader_thread->array_index);
-    //    }
-    //    if (saved_errno != EAGAIN)
-    //    {
-    //        if (saved_errno == ECONNREFUSED)
-    //        {
-    //            logger(1,
-    //                   "[%8llu, %zu] %s to %s refused by endpoint",
-    //                   workflow->packets_captured,
-    //                   reader_thread->array_index,
-    //                   (collector_address.raw.sa_family == AF_UNIX ? "Connection" : "Datagram"),
-    //                   get_cmdarg(&nDPId_options.collector_address));
-    //        }
-    //        reader_thread->collector_sock_last_errno = saved_errno;
-    //    }
-    //    else if (collector_address.raw.sa_family == AF_UNIX)
-    //    {
-    //        size_t pos = (written < 0 ? 0 : written);
-    //        set_collector_block(reader_thread);
-    //        while ((size_t)(written = write(reader_thread->collector_sockfd, newline_json_msg + pos, s_ret - pos)) !=
-    //               s_ret - pos)
-    //        {
-    //            saved_errno = errno;
-    //            if (saved_errno == EPIPE || written == 0)
-    //            {
-    //                logger(1,
-    //                       "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
-    //                       workflow->packets_captured,
-    //                       reader_thread->array_index);
-    //                reader_thread->collector_sock_last_errno = saved_errno;
-    //                break;
-    //            }
-    //            else if (written < 0)
-    //            {
-    //                logger(1,
-    //                       "[%8llu, %zu] Send data (blocking I/O) to nDPIsrvd Collector at %s failed: %s",
-    //                       workflow->packets_captured,
-    //                       reader_thread->array_index,
-    //                       get_cmdarg(&nDPId_options.collector_address),
-    //                       strerror(saved_errno));
-    //                reader_thread->collector_sock_last_errno = saved_errno;
-    //                break;
-    //            }
-    //            else
-    //            {
-    //                pos += written;
-    //            }
-    //        }
-    //        set_collector_nonblock(reader_thread);
-    //    }
-    //}
+    if (reader_thread->collector_sock_last_errno == 0 &&
+        (written = write(reader_thread->collector_sockfd, newline_json_msg, s_ret)) != s_ret)
+    {
+        saved_errno = errno;
+        if (saved_errno == EPIPE || written == 0)
+        {
+            logger(1,
+                   "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
+                   workflow->packets_captured,
+                   reader_thread->array_index);
+        }
+        if (saved_errno != EAGAIN)
+        {
+            if (saved_errno == ECONNREFUSED)
+            {
+                logger(1,
+                       "[%8llu, %zu] %s to %s refused by endpoint",
+                       workflow->packets_captured,
+                       reader_thread->array_index,
+                       (collector_address.raw.sa_family == AF_UNIX ? "Connection" : "Datagram"),
+                       get_cmdarg(&nDPId_options.collector_address));
+            }
+            reader_thread->collector_sock_last_errno = saved_errno;
+        }
+        else if (collector_address.raw.sa_family == AF_UNIX)
+        {
+            size_t pos = (written < 0 ? 0 : written);
+            set_collector_block(reader_thread);
+            while ((size_t)(written = write(reader_thread->collector_sockfd, newline_json_msg + pos, s_ret - pos)) !=
+                   s_ret - pos)
+            {
+                saved_errno = errno;
+                if (saved_errno == EPIPE || written == 0)
+                {
+                    logger(1,
+                           "[%8llu, %zu] Lost connection to nDPIsrvd Collector",
+                           workflow->packets_captured,
+                           reader_thread->array_index);
+                    reader_thread->collector_sock_last_errno = saved_errno;
+                    break;
+                }
+                else if (written < 0)
+                {
+                    logger(1,
+                           "[%8llu, %zu] Send data (blocking I/O) to nDPIsrvd Collector at %s failed: %s",
+                           workflow->packets_captured,
+                           reader_thread->array_index,
+                           get_cmdarg(&nDPId_options.collector_address),
+                           strerror(saved_errno));
+                    reader_thread->collector_sock_last_errno = saved_errno;
+                    break;
+                }
+                else
+                {
+                    pos += written;
+                }
+            }
+            set_collector_nonblock(reader_thread);
+        }
+    }
 
    logger(0, "ASHWANI: After call to write");
 }

--- a/nDPId.c
+++ b/nDPId.c
@@ -2281,11 +2281,12 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
 
     if (prev_length == json_msg_len && memcmp(prev_message, json_str, json_msg_len) == 0)
     {       
-        return;
+        return 1;
     }
 
     prev_message = json_str;
     prev_length = json_msg_len;
+    return -1;
 }
 
 static write_to_file(const char * json_str, size_t json_msg_len)

--- a/nDPId.c
+++ b/nDPId.c
@@ -2273,7 +2273,7 @@ int duplicate_data(const char * json_str, size_t json_msg_len)
     static const char * prev_message = NULL;
     static size_t prev_length = 0;
 
-    if (prev_length == json_msg_len && std::memcmp(prev_message, json_msg, json_msg_len) == 0)
+    if (prev_length == json_msg_len && memcmp(prev_message, json_msg, json_msg_len) == 0)
     {       
         return;
     }

--- a/nDPId.c
+++ b/nDPId.c
@@ -4614,8 +4614,10 @@ static void run_pcap_loop(struct nDPId_reader_thread * const reader_thread, char
     {
         if (reader_thread->workflow->is_pcap_file != 0)
         {
+            logger(0, "Ashwani: before pcap_loop");
             switch (pcap_loop(reader_thread->workflow->pcap_handle, -1, &ndpi_process_packet, (uint8_t *)reader_thread))
             {
+                logger(0, "Ashwani: Inside Switch");
                 case PCAP_ERROR:
                     logger(1, "Error while reading pcap file: '%s'", pcap_geterr(reader_thread->workflow->pcap_handle));
                     MT_GET_AND_ADD(reader_thread->workflow->error_or_eof, 1);
@@ -4769,8 +4771,9 @@ static void run_pcap_loop(struct nDPId_reader_thread * const reader_thread, char
                     }
                     else
 #endif
-                        if (fd == pcap_fd)
+                    if (fd == pcap_fd)
                     {
+                        logger(0, "Ashwani: fd == pcap_fd");
                         switch (pcap_dispatch(
                             reader_thread->workflow->pcap_handle, -1, ndpi_process_packet, (uint8_t *)reader_thread))
                         {
@@ -4795,6 +4798,7 @@ static void run_pcap_loop(struct nDPId_reader_thread * const reader_thread, char
                 }
             }
 
+            logger(0, "before nio_free call");
             nio_free(&io);
         }
     }

--- a/nDPId.c
+++ b/nDPId.c
@@ -2591,13 +2591,17 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     {
         logger(0, "Ashwani converted_json_str = %s", converted_json_str);
         int length = strlen(converted_json_str);
+        logger(0, "Ashwani write_to_file 1");
         if (duplicate_data(converted_json_str, length))
         {
+            logger(0, "Ashwani write_to_file duplicate_data");
             return;
         }
 
+        logger(0, "Ashwani write_to_file 2");
         if (length != 0)
         {
+            logger(0, "Ashwani write_to_file 3");
             char * converted_json_str_no_risk = NULL;
             if (createAlert)
             {
@@ -2608,6 +2612,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
             }
             else
              {
+                logger(0, "Ashwani write_to_file 4");
                  add_or_update_flow_entry(flow_map_ref, flow_id, converted_json_str, NULL);                  
              }
                 

--- a/nDPId.c
+++ b/nDPId.c
@@ -877,7 +877,7 @@ static void ndpi_comp_scan_walker(void const * const A, ndpi_VISIT which, int de
                     {
                         logger(1,
                                "zLib compression failed for flow %llu with error code: %d",
-                               flow->flow_extended.flow_id,
+                               flow->flow_extended.hashval,
                                ret);
                     }
                     else
@@ -2183,7 +2183,7 @@ static void jsonize_daemon(struct nDPId_reader_thread * const reader_thread, enu
 
 static void jsonize_flow(struct nDPId_workflow * const workflow, struct nDPId_flow_extended const * const flow_ext)
 {
-    ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->flow_id);
+    ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->hashval);
     ndpi_serialize_string_string(&workflow->ndpi_serializer,
                                  "flow_state",
                                  flow_state_name_table[flow_ext->flow_basic.state]);
@@ -2268,19 +2268,69 @@ static int connect_to_collector(struct nDPId_reader_thread * const reader_thread
     return 0;
 }
 
+/*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
+// Define a linked list node to store each unique message
+typedef struct MessageNode
+{
+    char * message;
+    size_t length;
+    struct MessageNode * next;
+} MessageNode;
+
+// Head of the linked list
+static MessageNode * head = NULL;
+
+// Function to check for duplicates and add new messages
 int duplicate_data(const char * json_str, size_t json_msg_len)
 {
-    static const char * prev_message = NULL;
-    static size_t prev_length = 0;
+    MessageNode * current = head;
 
-    if (prev_length == json_msg_len && memcmp(prev_message, json_str, json_msg_len) == 0)
-    {       
-        return 1;
+    // Check if the current message is a duplicate
+    while (current != NULL)
+    {
+        if (current->length == json_msg_len && memcmp(current->message, json_str, json_msg_len) == 0)
+        {
+            return 1; // Duplicate found
+        }
+        current = current->next;
     }
 
-    prev_message = json_str;
-    prev_length = json_msg_len;
-    return 0;
+    // If not a duplicate, add the new message to the linked list
+    MessageNode * new_node = (MessageNode *)malloc(sizeof(MessageNode));
+    if (new_node == NULL)
+    {
+        logger(1, "Failed to allocate memory for new node");
+        return 0;
+    }
+
+    new_node->message = (char *)malloc(json_msg_len);
+    if (new_node->message == NULL)
+    {
+        logger(1, "Failed to allocate memory for message");
+        free(new_node);
+        return 0;
+    }
+
+    memcpy(new_node->message, json_str, json_msg_len);
+    new_node->length = json_msg_len;
+    new_node->next = head;
+    head = new_node;
+
+    return 0; // No duplicate
+}
+
+// Function to free the linked list memory
+void free_messages()
+{
+    MessageNode * current = head;
+    while (current != NULL)
+    {
+        MessageNode * temp = current;
+        current = current->next;
+        free(temp->message);
+        free(temp);
+    }
+    head = NULL;
 }
 
 static write_to_file(const char * json_str, size_t json_msg_len)
@@ -2355,6 +2405,7 @@ static write_to_file(const char * json_str, size_t json_msg_len)
     free(converted_json_str);
 }
 
+/*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
 static void send_to_collector(struct nDPId_reader_thread * const reader_thread,
                               char const * const json_msg,
                               size_t json_msg_len)
@@ -2734,7 +2785,7 @@ static void jsonize_packet_event(struct nDPId_reader_thread * const reader_threa
 
     if (event == PACKET_EVENT_PAYLOAD_FLOW)
     {
-        ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->flow_id);
+        ndpi_serialize_string_uint64(&workflow->ndpi_serializer, "flow_id", flow_ext->hashval);
         ndpi_serialize_string_uint64(&workflow->ndpi_serializer,
                                      "flow_packet_id",
                                      flow_ext->packets_processed[FD_SRC2DST] + flow_ext->packets_processed[FD_DST2SRC]);
@@ -2877,7 +2928,7 @@ static void jsonize_flow_event(struct nDPId_reader_thread * const reader_thread,
             logger(1,
                    "[%8llu, %4llu] internal error / invalid function call",
                    workflow->packets_captured,
-                   flow_ext->flow_id);
+                   flow_ext->hashval);
             break;
     }
 
@@ -2918,7 +2969,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
             logger(1,
                    "[%8llu, %4llu] internal error / invalid function call",
                    workflow->packets_captured,
-                   flow->flow_extended.flow_id);
+                   flow->flow_extended.hashval);
             break;
 
         case FLOW_EVENT_NOT_DETECTED:
@@ -2931,7 +2982,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
                 logger(1,
                        "[%8llu, %4llu] ndpi_dpi2json failed for not-detected/guessed flow",
                        workflow->packets_captured,
-                       flow->flow_extended.flow_id);
+                       flow->flow_extended.hashval);
             }
             break;
 
@@ -2945,7 +2996,7 @@ static void jsonize_flow_detection_event(struct nDPId_reader_thread * const read
                 logger(1,
                        "[%8llu, %4llu] ndpi_dpi2json failed for detected/detection-update flow",
                        workflow->packets_captured,
-                       flow->flow_extended.flow_id);
+                       flow->flow_extended.hashval);
             }
             break;
     }
@@ -4156,7 +4207,7 @@ static void ndpi_process_packet(uint8_t * const args,
         }
 
         workflow->total_active_flows++;
-        flow_to_process->flow_extended.flow_id = MT_GET_AND_ADD(global_flow_id, 1);
+        flow_to_process->flow_extended.hashval = MT_GET_AND_ADD(global_flow_id, 1);
 
         if (alloc_detection_data(flow_to_process) != 0)
         {
@@ -4219,7 +4270,7 @@ static void ndpi_process_packet(uint8_t * const args,
                     workflow->current_compression_diff += flow_to_process->info.detection_data_compressed_size;
                     logger(1,
                            "zLib decompression failed for existing flow %llu with error code: %d",
-                           flow_to_process->flow_extended.flow_id,
+                           flow_to_process->flow_extended.hashval,
                            ret);
                     return;
                 }
@@ -4432,7 +4483,7 @@ static void ndpi_log_flow_walker(void const * const A, ndpi_VISIT which, int dep
                        "[%2zu][%4llu][last-seen: %13llu][last-update: %13llu][idle-time: %7llu][time-until-timeout: "
                        "%7llu]",
                        reader_thread->array_index,
-                       flow->flow_extended.flow_id,
+                       flow->flow_extended.hashval,
                        (unsigned long long int)last_seen,
                        (unsigned long long int)flow->flow_extended.last_flow_update,
                        (unsigned long long int)idle_time,
@@ -4452,7 +4503,7 @@ static void ndpi_log_flow_walker(void const * const A, ndpi_VISIT which, int dep
                        "[%2zu][%4llu][last-seen: %13llu][last-update: %13llu][idle-time: %7llu][time-until-timeout: "
                        "%7llu]",
                        reader_thread->array_index,
-                       flow->flow_extended.flow_id,
+                       flow->flow_extended.hashval,
                        (unsigned long long int)last_seen,
                        (unsigned long long int)flow->flow_extended.last_flow_update,
                        (unsigned long long int)idle_time,


### PR DESCRIPTION
This pull request introduces several changes to the `nDPIJsonDataConverter.c` and `nDPIJsonDataConverter.h` files, as well as minor changes to `nDPId-test.c`. The changes primarily focus on improving code readability, error handling, and data extraction from JSON objects. 

Key changes include:

Code readability and maintainability:

* Replaced hardcoded uninitialized number `-84742891` with a defined constant `RANDOM_UNINITIALIZED_NUMBER_VALUE` in `nDPIJsonDataConverter.c`. This change improves code readability and maintainability. [[1]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fR12) [[2]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL283-R288) [[3]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL476-R488) [[4]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL779-R793) [[5]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL1077-R1108) [[6]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL1113-R1156)

Data extraction and struct modifications:

* Modified the `struct Root_xfer` in `nDPIJsonDataConverter.c` to include two new fields: `flow_src_tot_l4_payload_len` and `flow_dst_tot_l4_payload_len`.
* Updated the `getRootDataStructure` and `getnDPIStructure` functions in `nDPIJsonDataConverter.c` to initialize newly added struct fields and replace hardcoded numbers with the defined constant. [[1]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL283-R288) [[2]](diffhunk://#diff-3b005f59311c6bf876ea92c3c2fbe6a0fc0973882ff7fb077b8713007160463fL476-R488)
* Changed the data extraction from JSON objects in the `getRootDataStructure` function in `nDPIJsonDataConverter.c` to fetch data from different JSON fields.
* Updated the `create_nDPI_Json_String` function in `nDPIJsonDataConverter.c` to check for uninitialized values using the defined constant.

Error handling:

* Improved error handling in the `fetch_files_to_process` function in `nDPId-test.c` by checking the return value of `malloc` and exiting the program in case of a memory allocation failure.

Minor changes:

* Removed debug log statements from `fetch_files_to_process` in `nDPId-test.c`.
* Added a new function `CheckSRCIPField` in `nDPIJsonDataConverter.c` to check if the `src_ip` field is present in a JSON string.
* Updated function prototypes in `nDPIJsonDataConverter.h` to reflect changes in `nDPIJsonDataConverter.c`.